### PR TITLE
Add Hugging Face and Cloudflare integration utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # AION
+
+Utilities for interacting with the Hugging Face Hub and Cloudflare REST APIs.
+
+## Features
+- **Hugging Face client** for listing models, retrieving model metadata, and downloading files from repositories.
+- **Cloudflare client** for listing zones and working with Workers KV namespaces.
+- **Command line interface** that wires both clients together for quick manual usage.
+
+## Installation
+The project only depends on the Python standard library. Clone the repository and run the CLI with Python 3.9+:
+
+```bash
+python -m aion.cli --help
+```
+
+## Usage
+### Hugging Face
+Provide a token via the `--token` flag or the `HF_TOKEN` environment variable.
+
+```bash
+# List models from an author
+python -m aion.cli huggingface list-models --author my-username
+
+# Download a file from a repo
+python -m aion.cli huggingface download my-username/my-model config.json --output ./config.json
+```
+
+### Cloudflare
+Provide a token via the `--token` flag or the `CLOUDFLARE_API_TOKEN` environment variable.
+
+```bash
+# List all accessible zones
+python -m aion.cli cloudflare list-zones
+
+# Create a Workers KV namespace (requires account id)
+python -m aion.cli cloudflare --account-id <ACCOUNT_ID> create-kv-namespace "My Namespace"
+```
+
+The CLI surfaces API errors with readable messages. See the unit tests in `tests/` for examples of how to mock the clients in automated workflows.
+
+## Running tests
+```bash
+python -m pytest
+```

--- a/aion/__init__.py
+++ b/aion/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for interacting with Hugging Face and Cloudflare APIs."""
+
+from .huggingface_client import HuggingFaceClient
+from .cloudflare_client import CloudflareClient
+from .exceptions import APIError
+
+__all__ = [
+    "HuggingFaceClient",
+    "CloudflareClient",
+    "APIError",
+]

--- a/aion/cli.py
+++ b/aion/cli.py
@@ -1,0 +1,115 @@
+"""Command line interface to interact with Hugging Face and Cloudflare."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from .cloudflare_client import CloudflareClient
+from .exceptions import APIError
+from .huggingface_client import HuggingFaceClient
+
+
+def _print_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _handle_huggingface(args: argparse.Namespace) -> None:
+    token = args.token or os.getenv("HF_TOKEN")
+    client = HuggingFaceClient(token=token)
+
+    if args.action == "list-models":
+        models = client.list_models(author=args.author, limit=args.limit)
+        _print_json(models)
+    elif args.action == "model-card":
+        card = client.get_model_card(args.model_id)
+        _print_json(card)
+    elif args.action == "download":
+        destination = Path(args.output) if args.output else None
+        content = client.download_file(
+            args.repo_id,
+            args.filename,
+            revision=args.revision,
+            destination=destination,
+        )
+        if destination is None:
+            print(content.decode("utf-8", errors="replace"))
+        else:
+            print(f"Downloaded to {content}")
+
+
+def _handle_cloudflare(args: argparse.Namespace) -> None:
+    token = args.token or os.getenv("CLOUDFLARE_API_TOKEN")
+    if not token:
+        raise SystemExit("A Cloudflare API token is required")
+    client = CloudflareClient(token=token, account_id=args.account_id)
+
+    if args.action == "list-zones":
+        zones = client.list_zones(name=args.name)
+        _print_json(zones)
+    elif args.action == "create-kv-namespace":
+        result = client.create_kv_namespace(args.title)
+        _print_json(result)
+    elif args.action == "write-kv":
+        result = client.write_kv_value(args.namespace_id, args.key, args.value)
+        _print_json(result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interact with Hugging Face and Cloudflare services")
+    subparsers = parser.add_subparsers(dest="service", required=True)
+
+    hf_parser = subparsers.add_parser("huggingface", help="Commands for the Hugging Face Hub")
+    hf_parser.add_argument("--token", help="API token (defaults to HF_TOKEN environment variable)")
+    hf_sub = hf_parser.add_subparsers(dest="action", required=True)
+
+    list_models_parser = hf_sub.add_parser("list-models", help="List models available on the hub")
+    list_models_parser.add_argument("--author", help="Filter models by author")
+    list_models_parser.add_argument("--limit", type=int, default=10, help="Limit the number of models returned")
+
+    model_card_parser = hf_sub.add_parser("model-card", help="Fetch a model card")
+    model_card_parser.add_argument("model_id", help="The repository id of the model")
+
+    download_parser = hf_sub.add_parser("download", help="Download a file from a repository")
+    download_parser.add_argument("repo_id", help="Repository identifier (e.g. user/model)")
+    download_parser.add_argument("filename", help="Path to the file inside the repository")
+    download_parser.add_argument("--revision", default="main", help="Repository revision to download from")
+    download_parser.add_argument("--output", help="Destination path to write the file")
+
+    cf_parser = subparsers.add_parser("cloudflare", help="Commands for the Cloudflare API")
+    cf_parser.add_argument("--token", help="API token (defaults to CLOUDFLARE_API_TOKEN environment variable)")
+    cf_parser.add_argument("--account-id", dest="account_id", help="Cloudflare account identifier")
+    cf_sub = cf_parser.add_subparsers(dest="action", required=True)
+
+    list_zones_parser = cf_sub.add_parser("list-zones", help="List Cloudflare zones")
+    list_zones_parser.add_argument("--name", help="Optional filter for a zone name")
+
+    kv_namespace_parser = cf_sub.add_parser("create-kv-namespace", help="Create a Workers KV namespace")
+    kv_namespace_parser.add_argument("title", help="Display title for the namespace")
+
+    kv_write_parser = cf_sub.add_parser("write-kv", help="Write a value to a Workers KV namespace")
+    kv_write_parser.add_argument("namespace_id", help="Namespace identifier")
+    kv_write_parser.add_argument("key", help="Key for the value")
+    kv_write_parser.add_argument("value", help="Value to store")
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.service == "huggingface":
+            _handle_huggingface(args)
+        elif args.service == "cloudflare":
+            _handle_cloudflare(args)
+    except APIError as exc:
+        raise SystemExit(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/aion/cloudflare_client.py
+++ b/aion/cloudflare_client.py
@@ -1,0 +1,93 @@
+"""Client helpers for Cloudflare's REST API."""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib import error, parse, request
+
+from .exceptions import APIError
+
+
+@dataclass
+class CloudflareClient:
+    """A lightweight helper for a subset of Cloudflare API operations."""
+
+    token: str
+    account_id: Optional[str] = None
+    base_url: str = "https://api.cloudflare.com/client/v4"
+
+    def _build_headers(self, content_type: str = "application/json") -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": content_type,
+        }
+        return headers
+
+    def list_zones(self, name: Optional[str] = None) -> Any:
+        """List Cloudflare zones accessible with the provided token."""
+
+        params = {"per_page": "50"}
+        if name:
+            params["name"] = name
+        query = parse.urlencode(params)
+        url = f"{self.base_url}/zones?{query}" if query else f"{self.base_url}/zones"
+        data = self._request(url)
+        return data.get("result", [])
+
+    def create_kv_namespace(self, title: str) -> Dict[str, Any]:
+        """Create a new Workers KV namespace."""
+
+        if not self.account_id:
+            raise ValueError("account_id is required for KV operations")
+        payload = json.dumps({"title": title}).encode("utf-8")
+        url = f"{self.base_url}/accounts/{self.account_id}/storage/kv/namespaces"
+        data = self._request(url, payload)
+        return data.get("result", {})
+
+    def write_kv_value(self, namespace_id: str, key: str, value: str) -> Dict[str, Any]:
+        """Write a value into a Workers KV namespace."""
+
+        if not self.account_id:
+            raise ValueError("account_id is required for KV operations")
+        encoded_key = parse.quote(key, safe="")
+        url = (
+            f"{self.base_url}/accounts/{self.account_id}/storage/kv/namespaces/"
+            f"{namespace_id}/values/{encoded_key}"
+        )
+        payload = value.encode("utf-8")
+        return self._request(url, payload, method="PUT", content_type="text/plain")
+
+    def _request(
+        self,
+        url: str,
+        data: Optional[bytes] = None,
+        method: Optional[str] = None,
+        content_type: str = "application/json",
+    ) -> Any:
+        try:
+            headers = self._build_headers(content_type=content_type)
+            req = request.Request(url, data=data, headers=headers)
+            if method is not None:
+                req.method = method
+            with closing(request.urlopen(req)) as resp:
+                payload = resp.read().decode("utf-8")
+            return self._parse_response(payload)
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Cloudflare", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Cloudflare", str(exc.reason)) from exc
+
+    @staticmethod
+    def _parse_response(payload: str) -> Any:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            raise APIError("Cloudflare", "Invalid JSON response")
+        if not data.get("success", False):
+            errors = data.get("errors") or "Unknown error"
+            raise APIError("Cloudflare", str(errors))
+        return data

--- a/aion/exceptions.py
+++ b/aion/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exceptions used by the AION service clients."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class APIError(RuntimeError):
+    """Represents an error returned by an external API service."""
+
+    service: str
+    message: str
+    status: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        status_text = f" (status: {self.status})" if self.status is not None else ""
+        super().__init__(f"{self.service} API error: {self.message}{status_text}")

--- a/aion/huggingface_client.py
+++ b/aion/huggingface_client.py
@@ -1,0 +1,90 @@
+"""Client helpers for the Hugging Face Hub REST API."""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from urllib import error, parse, request
+
+from .exceptions import APIError
+
+
+@dataclass
+class HuggingFaceClient:
+    """A minimal wrapper around the Hugging Face Hub API."""
+
+    token: Optional[str] = None
+    base_url: str = "https://huggingface.co"
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def list_models(self, author: Optional[str] = None, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return metadata about models available on the hub."""
+
+        params = {"limit": str(limit)}
+        if author:
+            params["author"] = author
+        query = parse.urlencode(params)
+        url = f"{self.base_url}/api/models?{query}" if query else f"{self.base_url}/api/models"
+        return self._get_json(url)
+
+    def get_model_card(self, model_id: str) -> Dict[str, Any]:
+        """Fetch detailed metadata for a specific model."""
+
+        url = f"{self.base_url}/api/models/{parse.quote(model_id, safe='')}"
+        return self._get_json(url)
+
+    def download_file(
+        self,
+        repo_id: str,
+        filename: str,
+        revision: str = "main",
+        destination: Optional[Path] = None,
+    ) -> Union[bytes, Path]:
+        """Download a file from a repository.
+
+        If *destination* is provided the contents are written to disk and the
+        path is returned. Otherwise the raw bytes are returned.
+        """
+
+        normalized_filename = filename.lstrip("/")
+        url = (
+            f"{self.base_url}/{parse.quote(repo_id, safe='')}/resolve/"
+            f"{parse.quote(revision, safe='')}/{parse.quote(normalized_filename)}"
+        )
+        content = self._get_bytes(url)
+        if destination is not None:
+            destination_path = Path(destination)
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            destination_path.write_bytes(content)
+            return destination_path
+        return content
+
+    def _get_json(self, url: str) -> Any:
+        try:
+            req = request.Request(url, headers=self._build_headers())
+            with closing(request.urlopen(req)) as resp:
+                return json.load(resp)
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face", str(exc.reason)) from exc
+
+    def _get_bytes(self, url: str) -> bytes:
+        try:
+            req = request.Request(url, headers=self._build_headers())
+            with closing(request.urlopen(req)) as resp:
+                return resp.read()
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face", str(exc.reason)) from exc

--- a/tests/test_cloudflare_client.py
+++ b/tests/test_cloudflare_client.py
@@ -1,0 +1,67 @@
+import io
+import json
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+import pytest
+
+from aion.cloudflare_client import CloudflareClient
+from aion.exceptions import APIError
+
+
+def _response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode("utf-8")
+    return resp
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_list_zones_uses_authorization_header(mock_urlopen: MagicMock) -> None:
+    mock_urlopen.return_value = _response({"success": True, "result": [{"name": "example.com"}]})
+    client = CloudflareClient(token="abc123")
+
+    result = client.list_zones()
+
+    assert result == [{"name": "example.com"}]
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header("Authorization") == "Bearer abc123"
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_create_kv_namespace_requires_account_id(mock_urlopen: MagicMock) -> None:
+    client = CloudflareClient(token="token")
+    with pytest.raises(ValueError):
+        client.create_kv_namespace("demo")
+    mock_urlopen.assert_not_called()
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_write_kv_value_parses_result(mock_urlopen: MagicMock) -> None:
+    mock_urlopen.return_value = _response({"success": True, "result": {"id": "ns"}})
+    client = CloudflareClient(token="token", account_id="account")
+
+    result = client.write_kv_value("namespace", "key", "value")
+
+    assert result == {"success": True, "result": {"id": "ns"}}
+    req = mock_urlopen.call_args[0][0]
+    assert req.method == "PUT"
+    assert req.get_header("Content-type") == "text/plain"
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_cloudflare_http_error(mock_urlopen: MagicMock) -> None:
+    http_error = error.HTTPError(
+        url="https://api.cloudflare.com/client/v4/zones",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b"{\"success\":false}"),
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = CloudflareClient(token="token")
+    with pytest.raises(APIError) as exc:
+        client.list_zones()
+
+    assert "Cloudflare API error" in str(exc.value)
+    assert exc.value.status == 403

--- a/tests/test_huggingface_client.py
+++ b/tests/test_huggingface_client.py
@@ -1,0 +1,63 @@
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+import pytest
+
+from aion.exceptions import APIError
+from aion.huggingface_client import HuggingFaceClient
+
+
+def _mock_response(payload: object) -> MagicMock:
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    return response
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_list_models_includes_author(mock_urlopen: MagicMock, tmp_path: Path) -> None:
+    mock_urlopen.return_value = _mock_response([{"modelId": "demo/model"}])
+
+    client = HuggingFaceClient(token="secret")
+    result = client.list_models(author="demo", limit=5)
+
+    assert result == [{"modelId": "demo/model"}]
+    request_obj = mock_urlopen.call_args[0][0]
+    assert request_obj.get_full_url().startswith("https://huggingface.co/api/models")
+    assert request_obj.get_header("Authorization") == "Bearer secret"
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_download_file_to_disk(mock_urlopen: MagicMock, tmp_path: Path) -> None:
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b"content"
+    mock_urlopen.return_value = mock_resp
+
+    destination = tmp_path / "model" / "config.json"
+    client = HuggingFaceClient()
+    output = client.download_file("demo/model", "config.json", destination=destination)
+
+    assert output == destination
+    assert destination.read_bytes() == b"content"
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_huggingface_http_error_raises_api_error(mock_urlopen: MagicMock) -> None:
+    error_payload = b"{\"error\": \"not found\"}"
+    http_error = error.HTTPError(
+        url="https://huggingface.co/api/models/demo",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=io.BytesIO(error_payload),
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = HuggingFaceClient()
+    with pytest.raises(APIError) as exc:
+        client.get_model_card("demo")
+
+    assert "Hugging Face API error" in str(exc.value)
+    assert exc.value.status == 404


### PR DESCRIPTION
## Summary
- add lightweight Hugging Face client for listing models, fetching metadata, and downloading repository files
- add Cloudflare client with zone listing and Workers KV helpers plus a combined CLI
- add unit tests and documentation covering usage and API error handling

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f2bec3ac83299e18e35038bbbb0d