### PR TITLE
Add Hugging Face Space integrations and Cloudflare worker proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
 # AION
+
+Toolkit code for integrating Hugging Face assets and Cloudflare Workers.
+
+## Features
+- **Hugging Face Hub client** – list models, fetch metadata, and download files without third-party dependencies.
+- **Hugging Face Space client** – call custom REST endpoints exposed by Spaces such as `darkfrostx/neuro-mechanism-backend` and `darkfrostx/ssra-auditor`.
+- **Cloudflare client** – manage zones and Workers KV namespaces from scripts or CI jobs.
+- **Space proxy Worker** – Cloudflare Worker project that forwards `/neuro/*` and `/auditor/*` requests to the corresponding Hugging Face Spaces, making it easy to expose them under your domain.
+- **Command line interface** that ties all of the above together for local experiments and automation.
+
+## Installation
+The Python components only depend on the standard library. Clone the repository and run the CLI with Python 3.9+:
+
+```bash
+python -m aion.cli --help
+```
+
+For the Cloudflare Worker, install dependencies inside `workers/space-proxy/`:
+
+```bash
+cd workers/space-proxy
+npm install
+```
+
+## CLI usage
+### Hugging Face Hub
+Provide a token via the `--token` flag or the `HF_TOKEN` environment variable.
+
+```bash
+# List models from an author
+python -m aion.cli huggingface list-models --author darkfrostx
+
+# Download a file from a repo
+python -m aion.cli huggingface download darkfrostx/some-model config.json --output ./config.json
+```
+
+### Hugging Face Spaces
+The CLI can talk directly to the two Spaces that need to be integrated with Cloudflare. Use `space-template` to view a ready-made request and then `space-get` / `space-post` to execute it.
+
+```bash
+# Inspect the suggested parameters/payload for each space
+python -m aion.cli huggingface space-template darkfrostx/neuro-mechanism-backend
+python -m aion.cli huggingface space-template darkfrostx/ssra-auditor
+
+# Call the neuro-mechanism backend (GET)
+python -m aion.cli huggingface space-get darkfrostx/neuro-mechanism-backend \
+  /mechanism_graph_manifest --param receptor=HTR2A --param symptom=apathy
+
+# A ready-to-use payload lives at `examples/auditor-request.json`.
+
+# Call the SSRA auditor (POST)
+python -m aion.cli huggingface space-post darkfrostx/ssra-auditor /audit \
+  --payload-file examples/auditor-request.json
+```
+
+### Cloudflare REST API helpers
+Provide a token via the `--token` flag or the `CLOUDFLARE_API_TOKEN` environment variable.
+
+```bash
+# List all accessible zones
+python -m aion.cli cloudflare list-zones
+
+# Create a Workers KV namespace (requires account id)
+python -m aion.cli cloudflare --account-id <ACCOUNT_ID> create-kv-namespace "My Namespace"
+```
+
+## Cloudflare Worker deployment
+The `workers/space-proxy` project contains a Wrangler configuration ready for the setup shown in the Cloudflare dashboard screenshot.
+
+1. From the repository root run `cd workers/space-proxy && npm install`.
+2. Authenticate Wrangler with `npx wrangler login` (or use `wrangler config --api-token ...`).
+3. Configure secrets used by the Worker:
+   ```bash
+   npx wrangler secret put HF_TOKEN           # optional – only if the Spaces require auth
+   npx wrangler secret put NEURO_SPACE        # defaults to darkfrostx/neuro-mechanism-backend
+   npx wrangler secret put AUDITOR_SPACE      # defaults to darkfrostx/ssra-auditor
+   ```
+4. Deploy with `npx wrangler deploy`.
+
+Requests that hit the Worker under `/neuro/*` are proxied to the neuro-mechanism backend Space, while `/auditor/*` flows to the SSRA auditor. The worker adds permissive CORS headers so that static sites or other clients can call these endpoints directly.
+
+You can also enable Pull Request previews in the Cloudflare dashboard by pointing the build command at `npx wrangler deploy` and setting `npx wrangler versions upload` for previews (as in the screenshot provided by the user).
+
+## Running tests
+```bash
+python -m pytest
+```

--- a/aion/__init__.py
+++ b/aion/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for interacting with Hugging Face and Cloudflare APIs."""
+
+from .huggingface_client import HuggingFaceClient
+from .cloudflare_client import CloudflareClient
+from .spaces_client import HuggingFaceSpaceClient
+from .exceptions import APIError
+
+__all__ = [
+    "HuggingFaceClient",
+    "HuggingFaceSpaceClient",
+    "CloudflareClient",
+    "APIError",
+]

--- a/aion/cli.py
+++ b/aion/cli.py
@@ -1,0 +1,202 @@
+"""Command line interface to interact with Hugging Face and Cloudflare."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .cloudflare_client import CloudflareClient
+from .exceptions import APIError
+from .huggingface_client import HuggingFaceClient
+from .spaces_client import HuggingFaceSpaceClient
+
+SPACE_TEMPLATES: Dict[str, Dict[str, Any]] = {
+    "darkfrostx/neuro-mechanism-backend": {
+        "description": "Fetch a sample mechanism graph manifest for receptor HTR2A and symptom apathy.",
+        "method": "GET",
+        "path": "/mechanism_graph_manifest",
+        "params": {"receptor": "HTR2A", "symptom": "apathy"},
+    },
+    "darkfrostx/ssra-auditor": {
+        "description": "Submit a minimal bundle to the SSRA auditor for evaluation.",
+        "method": "POST",
+        "path": "/audit",
+        "payload": {
+            "metrics": {"TCS": 0.2, "HDI": 0.4, "PDS": 0.25, "EVI": 1, "CBS": 0.3, "LQS": 0.4},
+            "bundle": {
+                "network": {"data": [{"source": "HTR2A", "target": "5-HT", "weight": 0.8}]},
+                "regions": {"data": {"regions_ranked": ["ACC", "PFC", "HPC"]}},
+                "literature": [
+                    {"title": "Selective serotonin reuptake modulates apathy", "pmid": "123456"}
+                ],
+            },
+        },
+    },
+}
+
+
+def _print_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _parse_kv_pairs(pairs: Optional[list[str]]) -> Dict[str, str]:
+    params: Dict[str, str] = {}
+    if not pairs:
+        return params
+    for item in pairs:
+        if "=" not in item:
+            raise SystemExit(f"Invalid parameter '{item}'. Expected key=value format.")
+        key, value = item.split("=", 1)
+        params[key] = value
+    return params
+
+
+def _load_payload(args: argparse.Namespace) -> Dict[str, Any]:
+    if args.payload_file:
+        payload_text = Path(args.payload_file).read_text(encoding="utf-8")
+    elif args.payload:
+        payload_text = args.payload
+    else:
+        raise SystemExit("A JSON payload is required (use --payload or --payload-file)")
+    try:
+        return json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON payload: {exc}")
+
+
+def _handle_huggingface(args: argparse.Namespace) -> None:
+    token = args.token or os.getenv("HF_TOKEN")
+    client = HuggingFaceClient(token=token)
+
+    if args.action == "list-models":
+        models = client.list_models(author=args.author, limit=args.limit)
+        _print_json(models)
+    elif args.action == "model-card":
+        card = client.get_model_card(args.model_id)
+        _print_json(card)
+    elif args.action == "download":
+        destination = Path(args.output) if args.output else None
+        content = client.download_file(
+            args.repo_id,
+            args.filename,
+            revision=args.revision,
+            destination=destination,
+        )
+        if destination is None:
+            print(content.decode("utf-8", errors="replace"))
+        else:
+            print(f"Downloaded to {content}")
+    elif args.action in {"space-get", "space-post", "space-template"}:
+        _handle_space(args, token)
+
+
+def _handle_space(args: argparse.Namespace, token: Optional[str]) -> None:
+    if args.action == "space-template":
+        template = SPACE_TEMPLATES.get(args.space_id)
+        if not template:
+            raise SystemExit(f"No template available for Space '{args.space_id}'.")
+        _print_json(template)
+        return
+
+    space_client = HuggingFaceSpaceClient(space_id=args.space_id, token=token)
+
+    if args.action == "space-get":
+        params = _parse_kv_pairs(args.params)
+        response = space_client.get(args.path, params=params or None)
+        _print_json(response)
+    elif args.action == "space-post":
+        payload = _load_payload(args)
+        response = space_client.post(args.path, payload)
+        _print_json(response)
+
+
+def _handle_cloudflare(args: argparse.Namespace) -> None:
+    token = args.token or os.getenv("CLOUDFLARE_API_TOKEN")
+    if not token:
+        raise SystemExit("A Cloudflare API token is required")
+    client = CloudflareClient(token=token, account_id=args.account_id)
+
+    if args.action == "list-zones":
+        zones = client.list_zones(name=args.name)
+        _print_json(zones)
+    elif args.action == "create-kv-namespace":
+        result = client.create_kv_namespace(args.title)
+        _print_json(result)
+    elif args.action == "write-kv":
+        result = client.write_kv_value(args.namespace_id, args.key, args.value)
+        _print_json(result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interact with Hugging Face and Cloudflare services")
+    subparsers = parser.add_subparsers(dest="service", required=True)
+
+    hf_parser = subparsers.add_parser("huggingface", help="Commands for the Hugging Face Hub")
+    hf_parser.add_argument("--token", help="API token (defaults to HF_TOKEN environment variable)")
+    hf_sub = hf_parser.add_subparsers(dest="action", required=True)
+
+    list_models_parser = hf_sub.add_parser("list-models", help="List models available on the hub")
+    list_models_parser.add_argument("--author", help="Filter models by author")
+    list_models_parser.add_argument("--limit", type=int, default=10, help="Limit the number of models returned")
+
+    model_card_parser = hf_sub.add_parser("model-card", help="Fetch a model card")
+    model_card_parser.add_argument("model_id", help="The repository id of the model")
+
+    download_parser = hf_sub.add_parser("download", help="Download a file from a repository")
+    download_parser.add_argument("repo_id", help="Repository identifier (e.g. user/model)")
+    download_parser.add_argument("filename", help="Path to the file inside the repository")
+    download_parser.add_argument("--revision", default="main", help="Repository revision to download from")
+    download_parser.add_argument("--output", help="Destination path to write the file")
+
+    space_get_parser = hf_sub.add_parser("space-get", help="Send a GET request to a Hugging Face Space")
+    space_get_parser.add_argument("space_id", help="Space identifier (e.g. owner/space-name)")
+    space_get_parser.add_argument("path", help="Endpoint path inside the Space (e.g. /health)")
+    space_get_parser.add_argument("--param", dest="params", action="append", help="Query parameter in key=value form (repeatable)")
+
+    space_post_parser = hf_sub.add_parser("space-post", help="Send a POST request to a Hugging Face Space")
+    space_post_parser.add_argument("space_id", help="Space identifier (e.g. owner/space-name)")
+    space_post_parser.add_argument("path", help="Endpoint path inside the Space")
+    group = space_post_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--payload", help="Inline JSON payload to send")
+    group.add_argument("--payload-file", help="Path to a JSON file to send")
+
+    space_template_parser = hf_sub.add_parser("space-template", help="Show a template payload/params for a known Space")
+    space_template_parser.add_argument("space_id", help="Space identifier (e.g. owner/space-name)")
+
+    cf_parser = subparsers.add_parser("cloudflare", help="Commands for the Cloudflare API")
+    cf_parser.add_argument("--token", help="API token (defaults to CLOUDFLARE_API_TOKEN environment variable)")
+    cf_parser.add_argument("--account-id", dest="account_id", help="Cloudflare account identifier")
+    cf_sub = cf_parser.add_subparsers(dest="action", required=True)
+
+    list_zones_parser = cf_sub.add_parser("list-zones", help="List Cloudflare zones")
+    list_zones_parser.add_argument("--name", help="Optional filter for a zone name")
+
+    kv_namespace_parser = cf_sub.add_parser("create-kv-namespace", help="Create a Workers KV namespace")
+    kv_namespace_parser.add_argument("title", help="Display title for the namespace")
+
+    kv_write_parser = cf_sub.add_parser("write-kv", help="Write a value to a Workers KV namespace")
+    kv_write_parser.add_argument("namespace_id", help="Namespace identifier")
+    kv_write_parser.add_argument("key", help="Key for the value")
+    kv_write_parser.add_argument("value", help="Value to store")
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.service == "huggingface":
+            _handle_huggingface(args)
+        elif args.service == "cloudflare":
+            _handle_cloudflare(args)
+    except APIError as exc:
+        raise SystemExit(str(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    main()

--- a/aion/cloudflare_client.py
+++ b/aion/cloudflare_client.py
@@ -1,0 +1,93 @@
+"""Client helpers for Cloudflare's REST API."""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib import error, parse, request
+
+from .exceptions import APIError
+
+
+@dataclass
+class CloudflareClient:
+    """A lightweight helper for a subset of Cloudflare API operations."""
+
+    token: str
+    account_id: Optional[str] = None
+    base_url: str = "https://api.cloudflare.com/client/v4"
+
+    def _build_headers(self, content_type: str = "application/json") -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": content_type,
+        }
+        return headers
+
+    def list_zones(self, name: Optional[str] = None) -> Any:
+        """List Cloudflare zones accessible with the provided token."""
+
+        params = {"per_page": "50"}
+        if name:
+            params["name"] = name
+        query = parse.urlencode(params)
+        url = f"{self.base_url}/zones?{query}" if query else f"{self.base_url}/zones"
+        data = self._request(url)
+        return data.get("result", [])
+
+    def create_kv_namespace(self, title: str) -> Dict[str, Any]:
+        """Create a new Workers KV namespace."""
+
+        if not self.account_id:
+            raise ValueError("account_id is required for KV operations")
+        payload = json.dumps({"title": title}).encode("utf-8")
+        url = f"{self.base_url}/accounts/{self.account_id}/storage/kv/namespaces"
+        data = self._request(url, payload)
+        return data.get("result", {})
+
+    def write_kv_value(self, namespace_id: str, key: str, value: str) -> Dict[str, Any]:
+        """Write a value into a Workers KV namespace."""
+
+        if not self.account_id:
+            raise ValueError("account_id is required for KV operations")
+        encoded_key = parse.quote(key, safe="")
+        url = (
+            f"{self.base_url}/accounts/{self.account_id}/storage/kv/namespaces/"
+            f"{namespace_id}/values/{encoded_key}"
+        )
+        payload = value.encode("utf-8")
+        return self._request(url, payload, method="PUT", content_type="text/plain")
+
+    def _request(
+        self,
+        url: str,
+        data: Optional[bytes] = None,
+        method: Optional[str] = None,
+        content_type: str = "application/json",
+    ) -> Any:
+        try:
+            headers = self._build_headers(content_type=content_type)
+            req = request.Request(url, data=data, headers=headers)
+            if method is not None:
+                req.method = method
+            with closing(request.urlopen(req)) as resp:
+                payload = resp.read().decode("utf-8")
+            return self._parse_response(payload)
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Cloudflare", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Cloudflare", str(exc.reason)) from exc
+
+    @staticmethod
+    def _parse_response(payload: str) -> Any:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            raise APIError("Cloudflare", "Invalid JSON response")
+        if not data.get("success", False):
+            errors = data.get("errors") or "Unknown error"
+            raise APIError("Cloudflare", str(errors))
+        return data

--- a/aion/exceptions.py
+++ b/aion/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exceptions used by the AION service clients."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class APIError(RuntimeError):
+    """Represents an error returned by an external API service."""
+
+    service: str
+    message: str
+    status: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        status_text = f" (status: {self.status})" if self.status is not None else ""
+        super().__init__(f"{self.service} API error: {self.message}{status_text}")

--- a/aion/huggingface_client.py
+++ b/aion/huggingface_client.py
@@ -1,0 +1,90 @@
+"""Client helpers for the Hugging Face Hub REST API."""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from urllib import error, parse, request
+
+from .exceptions import APIError
+
+
+@dataclass
+class HuggingFaceClient:
+    """A minimal wrapper around the Hugging Face Hub API."""
+
+    token: Optional[str] = None
+    base_url: str = "https://huggingface.co"
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def list_models(self, author: Optional[str] = None, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return metadata about models available on the hub."""
+
+        params = {"limit": str(limit)}
+        if author:
+            params["author"] = author
+        query = parse.urlencode(params)
+        url = f"{self.base_url}/api/models?{query}" if query else f"{self.base_url}/api/models"
+        return self._get_json(url)
+
+    def get_model_card(self, model_id: str) -> Dict[str, Any]:
+        """Fetch detailed metadata for a specific model."""
+
+        url = f"{self.base_url}/api/models/{parse.quote(model_id, safe='')}"
+        return self._get_json(url)
+
+    def download_file(
+        self,
+        repo_id: str,
+        filename: str,
+        revision: str = "main",
+        destination: Optional[Path] = None,
+    ) -> Union[bytes, Path]:
+        """Download a file from a repository.
+
+        If *destination* is provided the contents are written to disk and the
+        path is returned. Otherwise the raw bytes are returned.
+        """
+
+        normalized_filename = filename.lstrip("/")
+        url = (
+            f"{self.base_url}/{parse.quote(repo_id, safe='')}/resolve/"
+            f"{parse.quote(revision, safe='')}/{parse.quote(normalized_filename)}"
+        )
+        content = self._get_bytes(url)
+        if destination is not None:
+            destination_path = Path(destination)
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+            destination_path.write_bytes(content)
+            return destination_path
+        return content
+
+    def _get_json(self, url: str) -> Any:
+        try:
+            req = request.Request(url, headers=self._build_headers())
+            with closing(request.urlopen(req)) as resp:
+                return json.load(resp)
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face", str(exc.reason)) from exc
+
+    def _get_bytes(self, url: str) -> bytes:
+        try:
+            req = request.Request(url, headers=self._build_headers())
+            with closing(request.urlopen(req)) as resp:
+                return resp.read()
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face", str(exc.reason)) from exc

--- a/aion/spaces_client.py
+++ b/aion/spaces_client.py
@@ -1,0 +1,83 @@
+"""Client helpers for interacting with Hugging Face Spaces."""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib import error, parse, request
+
+from .exceptions import APIError
+
+
+@dataclass
+class HuggingFaceSpaceClient:
+    """A lightweight REST client that targets a single Hugging Face Space."""
+
+    space_id: str
+    token: Optional[str] = None
+    domain: str = "hf.space"
+    timeout: Optional[float] = 30.0
+
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        """Perform a GET request against the Space."""
+
+        url = self._build_url(path)
+        if params:
+            query = parse.urlencode(params, doseq=True)
+            url = f"{url}?{query}"
+        return self._request(url, method="GET")
+
+    def post(self, path: str, payload: Dict[str, Any]) -> Any:
+        """Perform a POST request against the Space, sending JSON payload."""
+
+        url = self._build_url(path)
+        data = json.dumps(payload).encode("utf-8")
+        return self._request(url, data=data, method="POST", content_type="application/json")
+
+    # Internal helpers -------------------------------------------------
+
+    def _build_url(self, path: str) -> str:
+        slug = self.space_id.replace("/", "-")
+        normalized_path = "/" + path.lstrip("/")
+        return f"https://{slug}.{self.domain}{normalized_path}"
+
+    def _headers(self, *, content_type: Optional[str] = None) -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if content_type:
+            headers["Content-Type"] = content_type
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _request(
+        self,
+        url: str,
+        *,
+        method: str,
+        data: Optional[bytes] = None,
+        content_type: Optional[str] = None,
+        expect_json: bool = True,
+    ) -> Any:
+        headers = self._headers(content_type=content_type)
+        try:
+            req = request.Request(url, data=data, headers=headers, method=method)
+            with closing(request.urlopen(req, timeout=self.timeout)) as resp:
+                raw = resp.read()
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face Space", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face Space", str(exc.reason)) from exc
+
+        if not expect_json:
+            return raw
+
+        if not raw:
+            return None
+
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise APIError("Hugging Face Space", "Invalid JSON response") from exc

--- a/examples/auditor-request.json
+++ b/examples/auditor-request.json
@@ -1,0 +1,25 @@
+{
+  "metrics": {
+    "TCS": 0.2,
+    "HDI": 0.4,
+    "PDS": 0.25,
+    "EVI": 1,
+    "CBS": 0.3,
+    "LQS": 0.4
+  },
+  "bundle": {
+    "network": {
+      "data": [
+        { "source": "HTR2A", "target": "5-HT", "weight": 0.8 }
+      ]
+    },
+    "regions": {
+      "data": {
+        "regions_ranked": ["ACC", "PFC", "HPC"]
+      }
+    },
+    "literature": [
+      { "title": "Selective serotonin reuptake modulates apathy", "pmid": "123456" }
+    ]
+  }
+}

--- a/tests/test_cloudflare_client.py
+++ b/tests/test_cloudflare_client.py
@@ -1,0 +1,67 @@
+import io
+import json
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+import pytest
+
+from aion.cloudflare_client import CloudflareClient
+from aion.exceptions import APIError
+
+
+def _response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode("utf-8")
+    return resp
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_list_zones_uses_authorization_header(mock_urlopen: MagicMock) -> None:
+    mock_urlopen.return_value = _response({"success": True, "result": [{"name": "example.com"}]})
+    client = CloudflareClient(token="abc123")
+
+    result = client.list_zones()
+
+    assert result == [{"name": "example.com"}]
+    req = mock_urlopen.call_args[0][0]
+    assert req.get_header("Authorization") == "Bearer abc123"
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_create_kv_namespace_requires_account_id(mock_urlopen: MagicMock) -> None:
+    client = CloudflareClient(token="token")
+    with pytest.raises(ValueError):
+        client.create_kv_namespace("demo")
+    mock_urlopen.assert_not_called()
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_write_kv_value_parses_result(mock_urlopen: MagicMock) -> None:
+    mock_urlopen.return_value = _response({"success": True, "result": {"id": "ns"}})
+    client = CloudflareClient(token="token", account_id="account")
+
+    result = client.write_kv_value("namespace", "key", "value")
+
+    assert result == {"success": True, "result": {"id": "ns"}}
+    req = mock_urlopen.call_args[0][0]
+    assert req.method == "PUT"
+    assert req.get_header("Content-type") == "text/plain"
+
+
+@patch("aion.cloudflare_client.request.urlopen")
+def test_cloudflare_http_error(mock_urlopen: MagicMock) -> None:
+    http_error = error.HTTPError(
+        url="https://api.cloudflare.com/client/v4/zones",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b"{\"success\":false}"),
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = CloudflareClient(token="token")
+    with pytest.raises(APIError) as exc:
+        client.list_zones()
+
+    assert "Cloudflare API error" in str(exc.value)
+    assert exc.value.status == 403

--- a/tests/test_huggingface_client.py
+++ b/tests/test_huggingface_client.py
@@ -1,0 +1,63 @@
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+import pytest
+
+from aion.exceptions import APIError
+from aion.huggingface_client import HuggingFaceClient
+
+
+def _mock_response(payload: object) -> MagicMock:
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode("utf-8")
+    return response
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_list_models_includes_author(mock_urlopen: MagicMock, tmp_path: Path) -> None:
+    mock_urlopen.return_value = _mock_response([{"modelId": "demo/model"}])
+
+    client = HuggingFaceClient(token="secret")
+    result = client.list_models(author="demo", limit=5)
+
+    assert result == [{"modelId": "demo/model"}]
+    request_obj = mock_urlopen.call_args[0][0]
+    assert request_obj.get_full_url().startswith("https://huggingface.co/api/models")
+    assert request_obj.get_header("Authorization") == "Bearer secret"
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_download_file_to_disk(mock_urlopen: MagicMock, tmp_path: Path) -> None:
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = b"content"
+    mock_urlopen.return_value = mock_resp
+
+    destination = tmp_path / "model" / "config.json"
+    client = HuggingFaceClient()
+    output = client.download_file("demo/model", "config.json", destination=destination)
+
+    assert output == destination
+    assert destination.read_bytes() == b"content"
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_huggingface_http_error_raises_api_error(mock_urlopen: MagicMock) -> None:
+    error_payload = b"{\"error\": \"not found\"}"
+    http_error = error.HTTPError(
+        url="https://huggingface.co/api/models/demo",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=io.BytesIO(error_payload),
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = HuggingFaceClient()
+    with pytest.raises(APIError) as exc:
+        client.get_model_card("demo")
+
+    assert "Hugging Face API error" in str(exc.value)
+    assert exc.value.status == 404

--- a/tests/test_spaces_client.py
+++ b/tests/test_spaces_client.py
@@ -1,0 +1,59 @@
+import json
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+import pytest
+
+from aion.exceptions import APIError
+from aion.spaces_client import HuggingFaceSpaceClient
+
+
+@patch("aion.spaces_client.request.urlopen")
+def test_space_get_builds_correct_url(mock_urlopen: MagicMock) -> None:
+    response = MagicMock()
+    response.read.return_value = json.dumps({"ok": True}).encode("utf-8")
+    mock_urlopen.return_value = response
+
+    client = HuggingFaceSpaceClient("darkfrostx/ssra-auditor")
+    data = client.get("/health")
+
+    assert data == {"ok": True}
+    request_obj = mock_urlopen.call_args[0][0]
+    assert request_obj.full_url == "https://darkfrostx-ssra-auditor.hf.space/health"
+    assert request_obj.get_header("Accept") == "application/json"
+
+
+@patch("aion.spaces_client.request.urlopen")
+def test_space_post_sends_json_payload(mock_urlopen: MagicMock) -> None:
+    response = MagicMock()
+    response.read.return_value = json.dumps({"decision": "APPROVE"}).encode("utf-8")
+    mock_urlopen.return_value = response
+
+    client = HuggingFaceSpaceClient("darkfrostx/ssra-auditor", token="secret")
+    payload = {"metrics": {"TCS": 0.2}, "bundle": {}}
+    data = client.post("/audit", payload)
+
+    assert data == {"decision": "APPROVE"}
+    request_obj = mock_urlopen.call_args[0][0]
+    assert request_obj.full_url == "https://darkfrostx-ssra-auditor.hf.space/audit"
+    assert request_obj.get_header("Authorization") == "Bearer secret"
+    assert json.loads(request_obj.data.decode("utf-8")) == payload
+
+
+@patch("aion.spaces_client.request.urlopen")
+def test_space_http_error_raises_api_error(mock_urlopen: MagicMock) -> None:
+    http_error = error.HTTPError(
+        url="https://darkfrostx-ssra-auditor.hf.space/audit",
+        code=500,
+        msg="Internal Server Error",
+        hdrs=None,
+        fp=None,
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = HuggingFaceSpaceClient("darkfrostx/ssra-auditor")
+    with pytest.raises(APIError) as exc:
+        client.post("/audit", {"bundle": {}})
+
+    assert "Hugging Face Space API error" in str(exc.value)
+    assert exc.value.status == 500

--- a/workers/space-proxy/package.json
+++ b/workers/space-proxy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aion-space-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --remote"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240529.0",
+    "wrangler": "^3.75.0"
+  }
+}

--- a/workers/space-proxy/src/index.ts
+++ b/workers/space-proxy/src/index.ts
@@ -1,0 +1,125 @@
+interface Env {
+  HF_TOKEN?: string;
+  NEURO_SPACE?: string;
+  AUDITOR_SPACE?: string;
+}
+
+type SpaceRoute = {
+  prefix: string;
+  spaceId: string;
+};
+
+const DEFAULT_ROUTES: SpaceRoute[] = [
+  { prefix: "/neuro", spaceId: "darkfrostx/neuro-mechanism-backend" },
+  { prefix: "/auditor", spaceId: "darkfrostx/ssra-auditor" },
+];
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    const routes = buildRoutes(env);
+    const url = new URL(request.url);
+    const match = matchRoute(url.pathname, routes);
+
+    if (!match) {
+      return jsonResponse({ error: "Unknown route" }, 404);
+    }
+
+    const targetUrl = buildTargetUrl(match, url);
+    const init = await buildFetchInit(request, env);
+
+    try {
+      const upstream = await fetch(targetUrl, init);
+      const headers = new Headers(upstream.headers);
+      applyCors(headers);
+      return new Response(upstream.body, {
+        status: upstream.status,
+        headers,
+      });
+    } catch (err) {
+      return jsonResponse({ error: "Failed to reach Hugging Face Space", detail: String(err) }, 502);
+    }
+  },
+};
+
+function buildRoutes(env: Env): SpaceRoute[] {
+  const routes = [...DEFAULT_ROUTES];
+
+  if (env.NEURO_SPACE) {
+    routes[0] = { prefix: "/neuro", spaceId: env.NEURO_SPACE };
+  }
+  if (env.AUDITOR_SPACE) {
+    routes[1] = { prefix: "/auditor", spaceId: env.AUDITOR_SPACE };
+  }
+
+  return routes;
+}
+
+function matchRoute(pathname: string, routes: SpaceRoute[]): SpaceRoute | undefined {
+  for (const route of routes) {
+    if (pathname === route.prefix || pathname.startsWith(route.prefix + "/")) {
+      return route;
+    }
+  }
+  return undefined;
+}
+
+function buildTargetUrl(route: SpaceRoute, incoming: URL): string {
+  const slug = route.spaceId.replace(/\//g, "-");
+  const suffix = incoming.pathname.slice(route.prefix.length) || "/";
+  const normalized = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  const target = new URL(`https://${slug}.hf.space${normalized}`);
+  target.search = incoming.search;
+  return target.toString();
+}
+
+async function buildFetchInit(request: Request, env: Env): Promise<RequestInit> {
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.set("accept", headers.get("accept") ?? "application/json");
+  if (env.HF_TOKEN) {
+    headers.set("Authorization", `Bearer ${env.HF_TOKEN}`);
+  }
+  applyCors(headers);
+
+  let body: ArrayBuffer | undefined;
+  if (!isBodylessMethod(request.method)) {
+    body = await request.arrayBuffer();
+  }
+
+  return {
+    method: request.method,
+    headers,
+    body,
+    redirect: "follow",
+  };
+}
+
+function isBodylessMethod(method: string): boolean {
+  return method === "GET" || method === "HEAD";
+}
+
+function applyCors(headers: Headers): void {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    headers.set(key, value);
+  }
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload, null, 2), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...CORS_HEADERS,
+    },
+  });
+}

--- a/workers/space-proxy/tsconfig.json
+++ b/workers/space-proxy/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/workers/space-proxy/wrangler.toml
+++ b/workers/space-proxy/wrangler.toml
@@ -1,0 +1,9 @@
+name = "aion-space-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-05-12"
+usage_model = "bundled"
+workers_dev = true
+
+[vars]
+NEURO_SPACE = "darkfrostx/neuro-mechanism-backend"
+AUDITOR_SPACE = "darkfrostx/ssra-auditor"


### PR DESCRIPTION
## Summary
- add a Hugging Face Space client plus CLI commands for calling the neuro-mechanism backend and SSRA auditor spaces
- document usage, supply a sample auditor payload, and extend tests to cover the new client
- scaffold a Cloudflare Worker project that proxies /neuro/* and /auditor/* routes to the respective Hugging Face Spaces

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f2bec3ac83299e18e35038bbbb0d