### PR TITLE
Add Hugging Face Space tooling and Cloudflare Worker scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # AION
 
-Utilities for interacting with the Hugging Face Hub and Cloudflare REST APIs.
+Utilities for interacting with the Hugging Face Hub, Hugging Face Spaces, and Cloudflare services.
 
 ## Features
 - **Hugging Face client** for listing models, retrieving model metadata, and downloading files from repositories.
+- **Hugging Face Space client** with CLI helpers tailored to `darkfrostx/neuro-mechanism-backend` and `darkfrostx/ssra-auditor` plus reusable payload templates.
 - **Cloudflare client** for listing zones and working with Workers KV namespaces.
-- **Command line interface** that wires both clients together for quick manual usage.
+- **Command line interface** that wires all clients together for quick manual usage.
+- **Cloudflare Worker scaffold** that proxies `/neuro/*` and `/auditor/*` routes to the Spaces, ready for Wrangler deploys.
 
 ## Installation
 The project only depends on the Python standard library. Clone the repository and run the CLI with Python 3.9+:
@@ -38,6 +40,66 @@ python -m aion.cli cloudflare --account-id <ACCOUNT_ID> create-kv-namespace "My 
 ```
 
 The CLI surfaces API errors with readable messages. See the unit tests in `tests/` for examples of how to mock the clients in automated workflows.
+
+### Hugging Face Spaces
+The CLI can now talk directly to Spaces, including the two services you linked (`darkfrostx/neuro-mechanism-backend` and `darkfrostx/ssra-auditor`).
+
+#### Quick shortcuts
+
+```bash
+# Health check against the neuro backend (defaults to /health)
+python -m aion.cli huggingface space neuro-backend
+
+# Request the mechanism graph manifest with query parameters from the sample template
+python -m aion.cli huggingface space neuro-backend \
+  --path mechanism_graph_manifest \
+  --query receptor=HTR2A --query symptom=apathy
+
+# Invoke the SSRA auditor with the ready-made payload template
+python -m aion.cli huggingface space ssra-auditor \
+  --payload-file aion/templates/ssra_auditor_payload.json
+
+# Call any other Space endpoint explicitly
+python -m aion.cli huggingface space call darkfrostx/ssra-auditor \
+  --path audit --payload '{"bundle": {}, "metrics": {}}'
+```
+
+The command automatically prints JSON responses. If a Space returns binary content (e.g. a `.gz` archive) the CLI advises redirecting output to a file.
+
+Templates backing the shortcuts live under [`aion/templates/`](aion/templates). `neuro_manifest_query.json` documents a common query to the neuro backend, while `ssra_auditor_payload.json` is a drop-in request body for the auditor's `/audit` endpoint.
+
+### Cloudflare Worker proxy
+A scaffolded Worker that mirrors your dashboard configuration lives in [`cloudflare/worker`](cloudflare/worker/). It proxies:
+
+- `https://<worker-domain>/neuro/*` → `https://darkfrostx-neuro-mechanism-backend.hf.space`
+- `https://<worker-domain>/auditor/*` → `https://darkfrostx-ssra-auditor.hf.space`
+
+Key files:
+
+- `wrangler.toml` – base configuration and environment variable defaults.
+- `src/index.ts` – proxy implementation that forwards headers, query strings, and optionally sets bearer tokens stored as Worker secrets.
+- `package.json` / `tsconfig.json` – TypeScript + Wrangler tooling with a Prettier hook.
+
+To deploy:
+
+1. Install Wrangler and authenticate: `npm install -g wrangler && wrangler login`.
+2. From `cloudflare/worker/`, configure secrets if the Spaces require tokens:
+
+   ```bash
+   wrangler secret put NEURO_SPACE_TOKEN
+   wrangler secret put AUDITOR_SPACE_TOKEN
+   ```
+
+3. Adjust `wrangler.toml` (e.g. rename the Worker or set routes), then deploy:
+
+   ```bash
+   npm install
+   npm run deploy
+   ```
+
+4. In the Cloudflare dashboard, link the Worker to your repository (screenshot flow you shared) so `wrangler deploy` runs automatically when you push to `main`.
+
+Once published, sending requests to `/neuro/*` or `/auditor/*` on the Worker domain forwards them to the respective Hugging Face Space with preserved methods, bodies, and query parameters.
 
 ## Running tests
 ```bash

--- a/aion/__init__.py
+++ b/aion/__init__.py
@@ -1,11 +1,12 @@
 """Utilities for interacting with Hugging Face and Cloudflare APIs."""
 
-from .huggingface_client import HuggingFaceClient
+from .huggingface_client import HuggingFaceClient, HuggingFaceSpaceClient
 from .cloudflare_client import CloudflareClient
 from .exceptions import APIError
 
 __all__ = [
     "HuggingFaceClient",
+    "HuggingFaceSpaceClient",
     "CloudflareClient",
     "APIError",
 ]

--- a/aion/cli.py
+++ b/aion/cli.py
@@ -6,15 +6,81 @@ import argparse
 import json
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .cloudflare_client import CloudflareClient
 from .exceptions import APIError
-from .huggingface_client import HuggingFaceClient
+from .huggingface_client import HuggingFaceClient, HuggingFaceSpaceClient
+
+
+TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
 
 
 def _print_json(data: Any) -> None:
     print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _load_template(name: str) -> Any:
+    path = TEMPLATES_DIR / name
+    if not path.exists():
+        raise SystemExit(f"Template '{name}' was not found under {TEMPLATES_DIR}")
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Template '{name}' contains invalid JSON: {exc}") from exc
+
+
+def _resolve_payload(
+    inline_payload: Optional[str],
+    payload_file: Optional[str],
+    template_name: Optional[str] = None,
+) -> Tuple[Any, bool]:
+    if inline_payload and payload_file:
+        raise SystemExit("Provide either --payload or --payload-file, not both")
+
+    if payload_file:
+        try:
+            with Path(payload_file).open("r", encoding="utf-8") as handle:
+                return json.load(handle), True
+        except FileNotFoundError as exc:
+            raise SystemExit(f"Payload file '{payload_file}' could not be found") from exc
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Payload file '{payload_file}' is not valid JSON: {exc}") from exc
+
+    if inline_payload is not None:
+        try:
+            return json.loads(inline_payload), True
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Inline payload is not valid JSON: {exc}") from exc
+
+    if template_name:
+        return _load_template(template_name), True
+
+    return {}, False
+
+
+def _parse_key_value_args(pairs: Optional[List[str]]) -> Dict[str, List[str]]:
+    params: Dict[str, List[str]] = {}
+    for item in pairs or []:
+        if "=" not in item:
+            raise SystemExit(f"Parameters must be in key=value form; received '{item}'")
+        key, value = item.split("=", 1)
+        params.setdefault(key, []).append(value)
+    return params
+
+
+def _print_space_response(response: Any) -> None:
+    if isinstance(response, (dict, list)):
+        _print_json(response)
+    elif isinstance(response, bytes):
+        try:
+            text = response.decode("utf-8")
+        except UnicodeDecodeError:
+            raise SystemExit("The Space returned binary data; redirect to a file instead") from None
+        print(text)
+    else:
+        print(response)
 
 
 def _handle_huggingface(args: argparse.Namespace) -> None:
@@ -39,6 +105,32 @@ def _handle_huggingface(args: argparse.Namespace) -> None:
             print(content.decode("utf-8", errors="replace"))
         else:
             print(f"Downloaded to {content}")
+    elif args.action == "space":
+        _handle_huggingface_space(args)
+
+
+def _handle_huggingface_space(args: argparse.Namespace) -> None:
+    token = args.token or os.getenv("HF_TOKEN")
+    client = HuggingFaceSpaceClient(space_id=args.space_id, token=token)
+
+    params = _parse_key_value_args(getattr(args, "query", None))
+    payload, provided = _resolve_payload(
+        getattr(args, "payload", None),
+        getattr(args, "payload_file", None),
+        getattr(args, "payload_template", None),
+    )
+
+    send_payload = provided or getattr(args, "allow_empty_payload", False)
+    json_payload = payload if send_payload else None
+
+    response = client.request(
+        args.path,
+        method=args.method,
+        params=params or None,
+        json_payload=json_payload,
+        timeout=args.timeout,
+    )
+    _print_space_response(response)
 
 
 def _handle_cloudflare(args: argparse.Namespace) -> None:
@@ -78,6 +170,64 @@ def build_parser() -> argparse.ArgumentParser:
     download_parser.add_argument("filename", help="Path to the file inside the repository")
     download_parser.add_argument("--revision", default="main", help="Repository revision to download from")
     download_parser.add_argument("--output", help="Destination path to write the file")
+
+    space_parser = hf_sub.add_parser("space", help="Call Hugging Face Spaces endpoints")
+    space_parser.add_argument("--token", help="API token (defaults to HF_TOKEN environment variable)")
+    space_sub = space_parser.add_subparsers(dest="space_action", required=True)
+
+    def _add_space_common_arguments(
+        space_subparser: argparse.ArgumentParser,
+        *,
+        default_path: str,
+        default_method: str,
+    ) -> None:
+        space_subparser.add_argument(
+            "--path",
+            default=default_path,
+            help=f"Relative endpoint inside the Space (default: {default_path})",
+        )
+        space_subparser.add_argument(
+            "--method",
+            default=default_method,
+            help=f"HTTP method to use (default: {default_method})",
+        )
+        space_subparser.add_argument("--payload", help="Inline JSON payload to send")
+        space_subparser.add_argument("--payload-file", help="Path to a JSON payload file")
+        space_subparser.add_argument(
+            "--allow-empty-payload",
+            action="store_true",
+            help="Send an empty JSON object when no payload data is provided",
+        )
+        space_subparser.add_argument(
+            "--query",
+            action="append",
+            help="Append query parameters as key=value entries (repeatable)",
+        )
+        space_subparser.add_argument("--timeout", type=float, help="Optional request timeout in seconds")
+
+    space_call_parser = space_sub.add_parser("call", help="Call an arbitrary Space endpoint")
+    space_call_parser.add_argument("space_id", help="Space identifier (e.g. author/my-space)")
+    _add_space_common_arguments(space_call_parser, default_path="api/predict", default_method="POST")
+
+    neuro_parser = space_sub.add_parser(
+        "neuro-backend",
+        help="Shortcut for darkfrostx/neuro-mechanism-backend",
+    )
+    neuro_parser.set_defaults(
+        space_id="darkfrostx/neuro-mechanism-backend",
+        allow_empty_payload=False,
+    )
+    _add_space_common_arguments(neuro_parser, default_path="health", default_method="GET")
+
+    auditor_parser = space_sub.add_parser(
+        "ssra-auditor",
+        help="Shortcut for darkfrostx/ssra-auditor",
+    )
+    auditor_parser.set_defaults(
+        space_id="darkfrostx/ssra-auditor",
+        payload_template="ssra_auditor_payload.json",
+    )
+    _add_space_common_arguments(auditor_parser, default_path="audit", default_method="POST")
 
     cf_parser = subparsers.add_parser("cloudflare", help="Commands for the Cloudflare API")
     cf_parser.add_argument("--token", help="API token (defaults to CLOUDFLARE_API_TOKEN environment variable)")

--- a/aion/huggingface_client.py
+++ b/aion/huggingface_client.py
@@ -1,4 +1,4 @@
-"""Client helpers for the Hugging Face Hub REST API."""
+"""Client helpers for the Hugging Face Hub REST API and Spaces."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import json
 from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 from urllib import error, parse, request
 
 from .exceptions import APIError
@@ -88,3 +88,102 @@ class HuggingFaceClient:
             raise APIError("Hugging Face", message, status=exc.code) from exc
         except error.URLError as exc:  # pragma: no cover - network failure path
             raise APIError("Hugging Face", str(exc.reason)) from exc
+
+
+@dataclass
+class HuggingFaceSpaceClient:
+    """HTTP client for interacting with a specific Hugging Face Space."""
+
+    space_id: str
+    token: Optional[str] = None
+    base_url: str = "https://huggingface.co"
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def _build_url(self, path: str, params: Optional[Mapping[str, Union[str, Sequence[str]]]]) -> str:
+        encoded_space = parse.quote(self.space_id, safe="/")
+        normalized_path = path.lstrip("/")
+        url = f"{self.base_url}/spaces/{encoded_space}"
+        if normalized_path:
+            url = f"{url}/{normalized_path}"
+        if params:
+            query = parse.urlencode(params, doseq=True)
+            url = f"{url}?{query}"
+        return url
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        params: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
+        json_payload: Optional[Any] = None,
+        data: Optional[bytes] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        """Perform an HTTP request against the Space.
+
+        The response body is decoded as JSON when possible; otherwise the raw
+        bytes are returned.
+        """
+
+        if json_payload is not None and data is not None:
+            raise ValueError("Provide either json_payload or data, not both")
+
+        payload: Optional[bytes]
+        headers = self._build_headers()
+        if json_payload is not None:
+            payload = json.dumps(json_payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        else:
+            payload = data
+
+        url = self._build_url(path, params)
+        try:
+            req = request.Request(url, data=payload, headers=headers, method=method.upper())
+            with closing(request.urlopen(req, timeout=timeout)) as resp:
+                raw = resp.read()
+                if not raw:
+                    return {}
+                try:
+                    return json.loads(raw.decode("utf-8"))
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    return raw
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Hugging Face Space", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Hugging Face Space", str(exc.reason)) from exc
+
+    def get(
+        self,
+        path: str,
+        *,
+        params: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        """Convenience helper for ``GET`` requests."""
+
+        return self.request(path, method="GET", params=params, timeout=timeout)
+
+    def post(
+        self,
+        path: str,
+        *,
+        json_payload: Optional[Any] = None,
+        data: Optional[bytes] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        """Convenience helper for ``POST`` requests."""
+
+        return self.request(
+            path,
+            method="POST",
+            json_payload=json_payload,
+            data=data,
+            timeout=timeout,
+        )

--- a/aion/templates/neuro_manifest_query.json
+++ b/aion/templates/neuro_manifest_query.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "mechanism_graph_manifest",
+  "query": {
+    "receptor": "HTR2A",
+    "symptom": "apathy"
+  },
+  "notes": "Invoke with: python -m aion.cli huggingface space neuro-backend --path mechanism_graph_manifest --query receptor=HTR2A --query symptom=apathy"
+}

--- a/aion/templates/ssra_auditor_payload.json
+++ b/aion/templates/ssra_auditor_payload.json
@@ -1,0 +1,37 @@
+{
+  "bundle": {
+    "network": {
+      "data": [
+        {"source": "HTR2A", "target": "HTR2C", "weight": 0.82},
+        {"source": "HTR2A", "target": "SLC6A4", "weight": 0.65}
+      ]
+    },
+    "regions": {
+      "data": {
+        "regions_ranked": [
+          {"region": "Anterior cingulate cortex", "score": 0.91},
+          {"region": "Orbitofrontal cortex", "score": 0.77}
+        ]
+      }
+    },
+    "literature": [
+      {
+        "title": "HTR2A modulation reduces apathy in clinical trials",
+        "citation": "Doe et al. (2024)",
+        "summary": "Double-blind trial showing measurable symptom relief."
+      }
+    ]
+  },
+  "metrics": {
+    "TCS": 0.45,
+    "HDI": 0.8,
+    "PDS": 0.25,
+    "EVI": 2,
+    "CBS": 0.3,
+    "LQS": 0.4
+  },
+  "metadata": {
+    "session_id": "demo-session-001",
+    "auditor": "cli"
+  }
+}

--- a/cloudflare/worker/package.json
+++ b/cloudflare/worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aion-neuro-auditor-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240919.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3"
+  }
+}

--- a/cloudflare/worker/src/index.ts
+++ b/cloudflare/worker/src/index.ts
@@ -1,0 +1,103 @@
+export interface Env {
+  NEURO_SPACE_BASE: string;
+  AUDITOR_SPACE_BASE: string;
+  NEURO_SPACE_TOKEN?: string;
+  AUDITOR_SPACE_TOKEN?: string;
+}
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "cf-connecting-ip",
+  "cf-ew-via",
+  "cf-ray",
+  "cf-visitor",
+]);
+
+function buildTargetUrl(base: string, suffix: string, search: string): string {
+  const target = new URL(base);
+  const normalizedBase = target.pathname.endsWith("/")
+    ? target.pathname.slice(0, -1)
+    : target.pathname;
+  target.pathname = `${normalizedBase}/${suffix}`.replace(/\/+/g, "/");
+  target.search = search;
+  return target.toString();
+}
+
+async function proxySpace(
+  request: Request,
+  targetBase: string,
+  token: string | undefined,
+  suffix: string,
+  search: string,
+): Promise<Response> {
+  const init: RequestInit = {
+    method: request.method,
+    headers: new Headers(),
+    redirect: "manual",
+  };
+
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      init.headers!.set(key, value);
+    }
+  });
+
+  if (token) {
+    init.headers!.set("Authorization", `Bearer ${token}`);
+  }
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+  }
+
+  const response = await fetch(buildTargetUrl(targetBase, suffix, search), init);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: new Headers(response.headers),
+  });
+}
+
+function routeSuffix(url: URL, prefix: string): string {
+  const raw = url.pathname.slice(prefix.length);
+  return raw.replace(/^\//, "");
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/neuro/")) {
+      const suffix = routeSuffix(url, "/neuro");
+      return proxySpace(request, env.NEURO_SPACE_BASE, env.NEURO_SPACE_TOKEN, suffix, url.search);
+    }
+
+    if (url.pathname.startsWith("/auditor/")) {
+      const suffix = routeSuffix(url, "/auditor");
+      return proxySpace(request, env.AUDITOR_SPACE_BASE, env.AUDITOR_SPACE_TOKEN, suffix, url.search);
+    }
+
+    if (url.pathname === "/" || url.pathname === "") {
+      return Response.json(
+        {
+          ok: true,
+          message: "Proxy Worker online",
+          routes: {
+            neuro: "/neuro/*",
+            auditor: "/auditor/*",
+          },
+        },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};

--- a/cloudflare/worker/tsconfig.json
+++ b/cloudflare/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cloudflare/worker/wrangler.toml
+++ b/cloudflare/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "aion-neuro-auditor-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-09-05"
+workers_dev = true
+
+[vars]
+NEURO_SPACE_BASE = "https://darkfrostx-neuro-mechanism-backend.hf.space"
+AUDITOR_SPACE_BASE = "https://darkfrostx-ssra-auditor.hf.space"
+
+[observability]
+enabled = true

--- a/tests/test_huggingface_client.py
+++ b/tests/test_huggingface_client.py
@@ -7,7 +7,7 @@ from urllib import error
 import pytest
 
 from aion.exceptions import APIError
-from aion.huggingface_client import HuggingFaceClient
+from aion.huggingface_client import HuggingFaceClient, HuggingFaceSpaceClient
 
 
 def _mock_response(payload: object) -> MagicMock:
@@ -61,3 +61,51 @@ def test_huggingface_http_error_raises_api_error(mock_urlopen: MagicMock) -> Non
 
     assert "Hugging Face API error" in str(exc.value)
     assert exc.value.status == 404
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_space_client_posts_json(mock_urlopen: MagicMock) -> None:
+    response_payload = {"ok": True}
+    mock_response = _mock_response(response_payload)
+    mock_urlopen.return_value = mock_response
+
+    client = HuggingFaceSpaceClient("demo/space", token="secret")
+    payload = {"inputs": [1, 2, 3]}
+    result = client.post("api/predict", json_payload=payload)
+
+    assert result == response_payload
+    request_obj = mock_urlopen.call_args[0][0]
+    assert request_obj.get_header("Authorization") == "Bearer secret"
+    assert request_obj.data == json.dumps(payload).encode("utf-8")
+    assert request_obj.get_full_url().endswith("/spaces/demo/space/api/predict")
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_space_client_returns_bytes_when_not_json(mock_urlopen: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.read.return_value = b"binary"
+    mock_urlopen.return_value = mock_response
+
+    client = HuggingFaceSpaceClient("demo/space")
+    result = client.get("artifact.tar.gz")
+
+    assert result == b"binary"
+
+
+@patch("aion.huggingface_client.request.urlopen")
+def test_space_client_http_error_raises_api_error(mock_urlopen: MagicMock) -> None:
+    http_error = error.HTTPError(
+        url="https://huggingface.co/spaces/demo/space/api/predict",
+        code=500,
+        msg="Internal Server Error",
+        hdrs=None,
+        fp=io.BytesIO(b"{\"error\": \"boom\"}"),
+    )
+    mock_urlopen.side_effect = http_error
+
+    client = HuggingFaceSpaceClient("demo/space")
+    with pytest.raises(APIError) as exc:
+        client.post("api/predict", json_payload={})
+
+    assert "Hugging Face Space API error" in str(exc.value)
+    assert exc.value.status == 500


### PR DESCRIPTION
## Summary
- add a Hugging Face Space client plus CLI shortcuts for the neuro-mechanism backend and SSRA auditor, including reusable JSON payload templates
- document the new Space workflows alongside Cloudflare Worker deployment steps tailored to the linked Hugging Face Spaces
- scaffold a Cloudflare Worker project that proxies `/neuro/*` and `/auditor/*` traffic to the Spaces with configurable secrets and TypeScript tooling

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3674f96c832999cbaa122860fdac