### PR TITLE
Refocus integrations on Hugging Face repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # AION
 
-Utilities for interacting with the Hugging Face Hub and Cloudflare REST APIs.
+Utilities for interacting with the Hugging Face Hub and Cloudflare services.
 
 ## Features
 - **Hugging Face client** for listing models, retrieving model metadata, and downloading files from repositories.
+- **Repository helpers** for surfacing metadata and file listings from any Hugging Face project, including `darkfrostx/neuro-mechanism-backend` and `darkfrostx/ssra-auditor`.
 - **Cloudflare client** for listing zones and working with Workers KV namespaces.
-- **Command line interface** that wires both clients together for quick manual usage.
+- **Command line interface** that wires all clients together for quick manual usage.
+- **Cloudflare Worker scaffold** that proxies `/neuro/*` and `/auditor/*` routes to the Hugging Face repositories, ready for Wrangler deploys.
 
 ## Installation
 The project only depends on the Python standard library. Clone the repository and run the CLI with Python 3.9+:
@@ -24,6 +26,12 @@ python -m aion.cli huggingface list-models --author my-username
 
 # Download a file from a repo
 python -m aion.cli huggingface download my-username/my-model config.json --output ./config.json
+
+# Fetch repository metadata
+python -m aion.cli huggingface repo-info darkfrostx/neuro-mechanism-backend
+
+# List files in a specific revision
+python -m aion.cli huggingface repo-files darkfrostx/ssra-auditor --revision main
 ```
 
 ### Cloudflare
@@ -38,6 +46,40 @@ python -m aion.cli cloudflare --account-id <ACCOUNT_ID> create-kv-namespace "My 
 ```
 
 The CLI surfaces API errors with readable messages. See the unit tests in `tests/` for examples of how to mock the clients in automated workflows.
+
+### Cloudflare Worker proxy
+A scaffolded Worker that mirrors your dashboard configuration lives in [`cloudflare/worker`](cloudflare/worker/). It proxies:
+
+- `https://<worker-domain>/neuro/*` → raw files from the `darkfrostx/neuro-mechanism-backend` repository
+- `https://<worker-domain>/auditor/*` → raw files from the `darkfrostx/ssra-auditor` repository
+
+Key files:
+
+- `wrangler.toml` – base configuration and environment variable defaults.
+- `src/index.ts` – proxy implementation that forwards headers to `https://huggingface.co/<repo>/resolve/<revision>/<path>`.
+- `package.json` / `tsconfig.json` – TypeScript + Wrangler tooling with a Prettier hook.
+
+To deploy:
+
+1. Install Wrangler and authenticate: `npm install -g wrangler && wrangler login`.
+2. From `cloudflare/worker/`, configure secrets if the repositories require tokens:
+
+   ```bash
+   wrangler secret put HF_API_TOKEN
+   wrangler secret put NEURO_REPO_TOKEN  # optional override per repository
+   wrangler secret put AUDITOR_REPO_TOKEN
+   ```
+
+3. Adjust `wrangler.toml` (e.g. rename the Worker, configure revisions, or set routes), then deploy:
+
+   ```bash
+   npm install
+   npm run deploy
+   ```
+
+4. In the Cloudflare dashboard, link the Worker to your Git repository (screenshot flow you shared) so `wrangler deploy` runs automatically when you push to `main`.
+
+Once published, sending requests to `/neuro/<path>` or `/auditor/<path>` on the Worker domain streams files straight from the configured Hugging Face repository revision. Provide `?revision=<branch>` to override the default per request.
 
 ## Running tests
 ```bash

--- a/aion/cli.py
+++ b/aion/cli.py
@@ -39,6 +39,12 @@ def _handle_huggingface(args: argparse.Namespace) -> None:
             print(content.decode("utf-8", errors="replace"))
         else:
             print(f"Downloaded to {content}")
+    elif args.action == "repo-info":
+        info = client.get_repo_info(args.repo_id, revision=args.revision)
+        _print_json(info)
+    elif args.action == "repo-files":
+        files = client.list_repo_files(args.repo_id, revision=args.revision)
+        _print_json(files)
 
 
 def _handle_cloudflare(args: argparse.Namespace) -> None:
@@ -78,6 +84,24 @@ def build_parser() -> argparse.ArgumentParser:
     download_parser.add_argument("filename", help="Path to the file inside the repository")
     download_parser.add_argument("--revision", default="main", help="Repository revision to download from")
     download_parser.add_argument("--output", help="Destination path to write the file")
+
+    repo_info_parser = hf_sub.add_parser(
+        "repo-info", help="Fetch metadata for a Hugging Face repository"
+    )
+    repo_info_parser.add_argument("repo_id", help="Repository identifier (e.g. user/model)")
+    repo_info_parser.add_argument(
+        "--revision",
+        help="Optional Git revision (branch, tag, or commit hash)",
+    )
+
+    repo_files_parser = hf_sub.add_parser(
+        "repo-files", help="List files inside a Hugging Face repository"
+    )
+    repo_files_parser.add_argument("repo_id", help="Repository identifier (e.g. user/model)")
+    repo_files_parser.add_argument(
+        "--revision",
+        help="Optional Git revision (branch, tag, or commit hash)",
+    )
 
     cf_parser = subparsers.add_parser("cloudflare", help="Commands for the Cloudflare API")
     cf_parser.add_argument("--token", help="API token (defaults to CLOUDFLARE_API_TOKEN environment variable)")

--- a/cloudflare/worker/package.json
+++ b/cloudflare/worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "aion-neuro-auditor-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240919.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.6.3"
+  }
+}

--- a/cloudflare/worker/src/index.ts
+++ b/cloudflare/worker/src/index.ts
@@ -1,0 +1,180 @@
+export interface Env {
+  HUGGING_FACE_API_BASE?: string;
+  HF_API_TOKEN?: string;
+  NEURO_REPO_ID: string;
+  AUDITOR_REPO_ID: string;
+  NEURO_REPO_REVISION?: string;
+  AUDITOR_REPO_REVISION?: string;
+  NEURO_REPO_TOKEN?: string;
+  AUDITOR_REPO_TOKEN?: string;
+}
+
+const DEFAULT_BASE = "https://huggingface.co";
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "cf-connecting-ip",
+  "cf-ew-via",
+  "cf-ray",
+  "cf-visitor",
+]);
+
+type Route = "neuro" | "auditor";
+
+interface RouteConfig {
+  repoId: string;
+  defaultRevision?: string;
+  token?: string;
+}
+
+function sanitizeHeaders(headers: Headers): Headers {
+  const result = new Headers();
+  headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      result.set(key, value);
+    }
+  });
+  return result;
+}
+
+function encodeRepoId(repoId: string): string {
+  return repoId
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function encodePath(path: string): string {
+  return path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildRepoResourceUrl(
+  base: string,
+  repoId: string,
+  revision: string,
+  suffix: string,
+  searchParams: URLSearchParams,
+): string {
+  if (!suffix) {
+    const url = new URL(`${base}/api/models/${encodeRepoId(repoId)}`);
+    if (revision) {
+      url.searchParams.set("revision", revision);
+    }
+    searchParams.forEach((value, key) => url.searchParams.append(key, value));
+    return url.toString();
+  }
+
+  const encodedPath = encodePath(suffix);
+  const target = new URL(
+    `${base}/${encodeRepoId(repoId)}/resolve/${encodeURIComponent(revision)}/${encodedPath}`,
+  );
+  const leftover = searchParams.toString();
+  if (leftover) {
+    target.search = leftover;
+  }
+  return target.toString();
+}
+
+function routeSuffix(url: URL, prefix: string): string {
+  const raw = url.pathname.slice(prefix.length);
+  return raw.replace(/^\//, "");
+}
+
+function pickRouteConfig(env: Env, route: Route): RouteConfig {
+  if (route === "neuro") {
+    return {
+      repoId: env.NEURO_REPO_ID,
+      defaultRevision: env.NEURO_REPO_REVISION,
+      token: env.NEURO_REPO_TOKEN ?? env.HF_API_TOKEN,
+    };
+  }
+  return {
+    repoId: env.AUDITOR_REPO_ID,
+    defaultRevision: env.AUDITOR_REPO_REVISION,
+    token: env.AUDITOR_REPO_TOKEN ?? env.HF_API_TOKEN,
+  };
+}
+
+async function proxyRepository(
+  request: Request,
+  env: Env,
+  route: Route,
+  suffix: string,
+): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  const config = pickRouteConfig(env, route);
+  const revision = params.get("revision") ?? config.defaultRevision ?? "main";
+  params.delete("revision");
+
+  const base = env.HUGGING_FACE_API_BASE ?? DEFAULT_BASE;
+  const targetUrl = buildRepoResourceUrl(base, config.repoId, revision, suffix, params);
+
+  const forwardHeaders = sanitizeHeaders(request.headers);
+  if (config.token) {
+    forwardHeaders.set("Authorization", `Bearer ${config.token}`);
+  }
+
+  const init: RequestInit = {
+    method: request.method,
+    headers: forwardHeaders,
+    redirect: "manual",
+  };
+
+  const response = await fetch(targetUrl, init);
+  const responseHeaders = sanitizeHeaders(response.headers);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/neuro")) {
+      const suffix = routeSuffix(url, "/neuro");
+      return proxyRepository(request, env, "neuro", suffix);
+    }
+
+    if (url.pathname.startsWith("/auditor")) {
+      const suffix = routeSuffix(url, "/auditor");
+      return proxyRepository(request, env, "auditor", suffix);
+    }
+
+    if (url.pathname === "/" || url.pathname === "") {
+      return Response.json(
+        {
+          ok: true,
+          message: "Hugging Face repository proxy online",
+          routes: {
+            neuro: "/neuro/<path>?revision=<branch>",
+            auditor: "/auditor/<path>?revision=<branch>",
+          },
+        },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+};

--- a/cloudflare/worker/tsconfig.json
+++ b/cloudflare/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/cloudflare/worker/wrangler.toml
+++ b/cloudflare/worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "aion-neuro-auditor-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-09-05"
+workers_dev = true
+
+[vars]
+HUGGING_FACE_API_BASE = "https://huggingface.co"
+NEURO_REPO_ID = "darkfrostx/neuro-mechanism-backend"
+AUDITOR_REPO_ID = "darkfrostx/ssra-auditor"
+NEURO_REPO_REVISION = "main"
+AUDITOR_REPO_REVISION = "main"
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary
- remove the Hugging Face Space utilities in favor of direct repository metadata and file listing helpers
- update the CLI and documentation to emphasize repository-centric workflows and commands
- rework the Cloudflare Worker scaffold to proxy Hugging Face repository content with configurable revisions and tokens

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3674f96c832999cbaa122860fdac