### PR TITLE
Refocus Hugging Face tooling and worker on repositories

### DIFF
--- a/aion/__init__.py
+++ b/aion/__init__.py
@@ -1,12 +1,5 @@
 """Utilities for interacting with Hugging Face and Cloudflare APIs."""
 
-from .huggingface_client import HuggingFaceClient, HuggingFaceSpaceClient
-from .cloudflare_client import CloudflareClient
-from .exceptions import APIError
+from .huggingface_client import HuggingFaceClient
 
-__all__ = [
-    "HuggingFaceClient",
-    "HuggingFaceSpaceClient",
-    "CloudflareClient",
-    "APIError",
-]
+__all__ = ["HuggingFaceClient"]

--- a/aion/cli.py
+++ b/aion/cli.py
@@ -3,84 +3,28 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from .cloudflare_client import CloudflareClient
 from .exceptions import APIError
-from .huggingface_client import HuggingFaceClient, HuggingFaceSpaceClient
-
-
-TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+from .huggingface_client import HuggingFaceClient
 
 
 def _print_json(data: Any) -> None:
+    import json
+
     print(json.dumps(data, indent=2, sort_keys=True))
 
 
-def _load_template(name: str) -> Any:
-    path = TEMPLATES_DIR / name
-    if not path.exists():
-        raise SystemExit(f"Template '{name}' was not found under {TEMPLATES_DIR}")
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            return json.load(handle)
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
-        raise SystemExit(f"Template '{name}' contains invalid JSON: {exc}") from exc
-
-
-def _resolve_payload(
-    inline_payload: Optional[str],
-    payload_file: Optional[str],
-    template_name: Optional[str] = None,
-) -> Tuple[Any, bool]:
-    if inline_payload and payload_file:
-        raise SystemExit("Provide either --payload or --payload-file, not both")
-
-    if payload_file:
-        try:
-            with Path(payload_file).open("r", encoding="utf-8") as handle:
-                return json.load(handle), True
-        except FileNotFoundError as exc:
-            raise SystemExit(f"Payload file '{payload_file}' could not be found") from exc
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"Payload file '{payload_file}' is not valid JSON: {exc}") from exc
-
-    if inline_payload is not None:
-        try:
-            return json.loads(inline_payload), True
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"Inline payload is not valid JSON: {exc}") from exc
-
-    if template_name:
-        return _load_template(template_name), True
-
-    return {}, False
-
-
-def _parse_key_value_args(pairs: Optional[List[str]]) -> Dict[str, List[str]]:
-    params: Dict[str, List[str]] = {}
-    for item in pairs or []:
-        if "=" not in item:
-            raise SystemExit(f"Parameters must be in key=value form; received '{item}'")
-        key, value = item.split("=", 1)
-        params.setdefault(key, []).append(value)
-    return params
-
-
-def _print_space_response(response: Any) -> None:
-    if isinstance(response, (dict, list)):
-        _print_json(response)
-    elif isinstance(response, bytes):
-        try:
-            text = response.decode("utf-8")
-        except UnicodeDecodeError:
-            raise SystemExit("The Space returned binary data; redirect to a file instead") from None
-        print(text)
-    else:
-        print(response)
+def _parse_repo_type(repo_type: Optional[str]) -> str:
+    if repo_type is None:
+        return "model"
+    normalized = repo_type.lower()
+    if normalized not in {"model", "dataset", "space"}:
+        raise SystemExit("repo-type must be 'model', 'dataset', or 'space'")
+    return normalized
 
 
 def _handle_huggingface(args: argparse.Namespace) -> None:
@@ -105,32 +49,20 @@ def _handle_huggingface(args: argparse.Namespace) -> None:
             print(content.decode("utf-8", errors="replace"))
         else:
             print(f"Downloaded to {content}")
-    elif args.action == "space":
-        _handle_huggingface_space(args)
-
-
-def _handle_huggingface_space(args: argparse.Namespace) -> None:
-    token = args.token or os.getenv("HF_TOKEN")
-    client = HuggingFaceSpaceClient(space_id=args.space_id, token=token)
-
-    params = _parse_key_value_args(getattr(args, "query", None))
-    payload, provided = _resolve_payload(
-        getattr(args, "payload", None),
-        getattr(args, "payload_file", None),
-        getattr(args, "payload_template", None),
-    )
-
-    send_payload = provided or getattr(args, "allow_empty_payload", False)
-    json_payload = payload if send_payload else None
-
-    response = client.request(
-        args.path,
-        method=args.method,
-        params=params or None,
-        json_payload=json_payload,
-        timeout=args.timeout,
-    )
-    _print_space_response(response)
+    elif args.action == "repo-info":
+        repo_type = _parse_repo_type(args.repo_type)
+        info = client.get_repo_info(args.repo_id, repo_type=repo_type)
+        _print_json(info)
+    elif args.action == "repo-files":
+        repo_type = _parse_repo_type(args.repo_type)
+        files = client.list_repo_files(
+            args.repo_id,
+            repo_type=repo_type,
+            revision=args.revision,
+            path=args.path or "",
+            recursive=not args.non_recursive,
+        )
+        _print_json(files)
 
 
 def _handle_cloudflare(args: argparse.Namespace) -> None:
@@ -171,63 +103,41 @@ def build_parser() -> argparse.ArgumentParser:
     download_parser.add_argument("--revision", default="main", help="Repository revision to download from")
     download_parser.add_argument("--output", help="Destination path to write the file")
 
-    space_parser = hf_sub.add_parser("space", help="Call Hugging Face Spaces endpoints")
-    space_parser.add_argument("--token", help="API token (defaults to HF_TOKEN environment variable)")
-    space_sub = space_parser.add_subparsers(dest="space_action", required=True)
-
-    def _add_space_common_arguments(
-        space_subparser: argparse.ArgumentParser,
-        *,
-        default_path: str,
-        default_method: str,
-    ) -> None:
-        space_subparser.add_argument(
-            "--path",
-            default=default_path,
-            help=f"Relative endpoint inside the Space (default: {default_path})",
-        )
-        space_subparser.add_argument(
-            "--method",
-            default=default_method,
-            help=f"HTTP method to use (default: {default_method})",
-        )
-        space_subparser.add_argument("--payload", help="Inline JSON payload to send")
-        space_subparser.add_argument("--payload-file", help="Path to a JSON payload file")
-        space_subparser.add_argument(
-            "--allow-empty-payload",
-            action="store_true",
-            help="Send an empty JSON object when no payload data is provided",
-        )
-        space_subparser.add_argument(
-            "--query",
-            action="append",
-            help="Append query parameters as key=value entries (repeatable)",
-        )
-        space_subparser.add_argument("--timeout", type=float, help="Optional request timeout in seconds")
-
-    space_call_parser = space_sub.add_parser("call", help="Call an arbitrary Space endpoint")
-    space_call_parser.add_argument("space_id", help="Space identifier (e.g. author/my-space)")
-    _add_space_common_arguments(space_call_parser, default_path="api/predict", default_method="POST")
-
-    neuro_parser = space_sub.add_parser(
-        "neuro-backend",
-        help="Shortcut for darkfrostx/neuro-mechanism-backend",
+    repo_info_parser = hf_sub.add_parser(
+        "repo-info",
+        help="Show metadata for a repository",
     )
-    neuro_parser.set_defaults(
-        space_id="darkfrostx/neuro-mechanism-backend",
-        allow_empty_payload=False,
+    repo_info_parser.add_argument("repo_id", help="Repository identifier (e.g. user/name)")
+    repo_info_parser.add_argument(
+        "--repo-type",
+        dest="repo_type",
+        help="Repository type: model, dataset, or space (default: model)",
     )
-    _add_space_common_arguments(neuro_parser, default_path="health", default_method="GET")
 
-    auditor_parser = space_sub.add_parser(
-        "ssra-auditor",
-        help="Shortcut for darkfrostx/ssra-auditor",
+    repo_files_parser = hf_sub.add_parser(
+        "repo-files",
+        help="List files within a repository revision",
     )
-    auditor_parser.set_defaults(
-        space_id="darkfrostx/ssra-auditor",
-        payload_template="ssra_auditor_payload.json",
+    repo_files_parser.add_argument("repo_id", help="Repository identifier (e.g. user/name)")
+    repo_files_parser.add_argument(
+        "--repo-type",
+        dest="repo_type",
+        help="Repository type: model, dataset, or space (default: model)",
     )
-    _add_space_common_arguments(auditor_parser, default_path="audit", default_method="POST")
+    repo_files_parser.add_argument(
+        "--revision",
+        default="main",
+        help="Repository revision to inspect (default: main)",
+    )
+    repo_files_parser.add_argument(
+        "--path",
+        help="List files under a specific directory inside the repo",
+    )
+    repo_files_parser.add_argument(
+        "--non-recursive",
+        action="store_true",
+        help="Only show direct children of the requested path",
+    )
 
     cf_parser = subparsers.add_parser("cloudflare", help="Commands for the Cloudflare API")
     cf_parser.add_argument("--token", help="API token (defaults to CLOUDFLARE_API_TOKEN environment variable)")

--- a/aion/huggingface_client.py
+++ b/aion/huggingface_client.py
@@ -1,4 +1,4 @@
-"""Client helpers for the Hugging Face Hub REST API and Spaces."""
+"""Client helpers for the Hugging Face Hub REST API."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import json
 from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib import error, parse, request
 
 from .exceptions import APIError
@@ -19,11 +19,23 @@ class HuggingFaceClient:
     token: Optional[str] = None
     base_url: str = "https://huggingface.co"
 
-    def _build_headers(self) -> Dict[str, str]:
-        headers: Dict[str, str] = {"Accept": "application/json"}
+    def _build_headers(self, *, accept: str = "application/json") -> Dict[str, str]:
+        headers: Dict[str, str] = {"Accept": accept}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
         return headers
+
+    @staticmethod
+    def _normalize_repo_type(repo_type: str) -> str:
+        normalized = repo_type.lower().rstrip("s")
+        if normalized not in {"model", "dataset", "space"}:
+            raise ValueError("repo_type must be 'model', 'dataset', or 'space'")
+        return normalized + "s"
+
+    def _build_repo_api_url(self, repo_id: str, repo_type: str) -> str:
+        repo_scope = self._normalize_repo_type(repo_type)
+        encoded_id = parse.quote(repo_id, safe="/")
+        return f"{self.base_url}/api/{repo_scope}/{encoded_id}"
 
     def list_models(self, author: Optional[str] = None, limit: int = 10) -> List[Dict[str, Any]]:
         """Return metadata about models available on the hub."""
@@ -40,6 +52,49 @@ class HuggingFaceClient:
 
         url = f"{self.base_url}/api/models/{parse.quote(model_id, safe='')}"
         return self._get_json(url)
+
+    def get_repo_info(self, repo_id: str, repo_type: str = "model") -> Dict[str, Any]:
+        """Fetch metadata for any Hugging Face repository type."""
+
+        url = self._build_repo_api_url(repo_id, repo_type)
+        return self._get_json(url)
+
+    def list_repo_files(
+        self,
+        repo_id: str,
+        *,
+        repo_type: str = "model",
+        revision: str = "main",
+        path: str = "",
+        recursive: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """List files tracked inside a repository revision.
+
+        Parameters mirror the Hub tree endpoint: *path* limits the listing to a
+        directory and *recursive* controls whether nested files are returned.
+        """
+
+        base_url = self._build_repo_api_url(repo_id, repo_type)
+        encoded_revision = parse.quote(revision, safe="")
+        tree_url = f"{base_url}/tree/{encoded_revision}"
+        params: Dict[str, str] = {}
+        normalized_path = path.lstrip("/")
+        if normalized_path:
+            params["path"] = normalized_path
+        if recursive:
+            params["recursive"] = "1"
+        query = parse.urlencode(params)
+        if query:
+            tree_url = f"{tree_url}?{query}"
+        result = self._get_json(tree_url)
+        if isinstance(result, dict) and "tree" in result:
+            # Some Hub responses wrap results inside a ``tree`` key.
+            tree_data = result.get("tree")
+            if isinstance(tree_data, list):
+                return tree_data
+        if isinstance(result, list):
+            return result
+        raise APIError("Hugging Face", "Unexpected response format when listing files")
 
     def download_file(
         self,
@@ -80,7 +135,7 @@ class HuggingFaceClient:
 
     def _get_bytes(self, url: str) -> bytes:
         try:
-            req = request.Request(url, headers=self._build_headers())
+            req = request.Request(url, headers=self._build_headers(accept="*/*"))
             with closing(request.urlopen(req)) as resp:
                 return resp.read()
         except error.HTTPError as exc:
@@ -89,101 +144,3 @@ class HuggingFaceClient:
         except error.URLError as exc:  # pragma: no cover - network failure path
             raise APIError("Hugging Face", str(exc.reason)) from exc
 
-
-@dataclass
-class HuggingFaceSpaceClient:
-    """HTTP client for interacting with a specific Hugging Face Space."""
-
-    space_id: str
-    token: Optional[str] = None
-    base_url: str = "https://huggingface.co"
-
-    def _build_headers(self) -> Dict[str, str]:
-        headers: Dict[str, str] = {"Accept": "application/json"}
-        if self.token:
-            headers["Authorization"] = f"Bearer {self.token}"
-        return headers
-
-    def _build_url(self, path: str, params: Optional[Mapping[str, Union[str, Sequence[str]]]]) -> str:
-        encoded_space = parse.quote(self.space_id, safe="/")
-        normalized_path = path.lstrip("/")
-        url = f"{self.base_url}/spaces/{encoded_space}"
-        if normalized_path:
-            url = f"{url}/{normalized_path}"
-        if params:
-            query = parse.urlencode(params, doseq=True)
-            url = f"{url}?{query}"
-        return url
-
-    def request(
-        self,
-        path: str,
-        *,
-        method: str = "GET",
-        params: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
-        json_payload: Optional[Any] = None,
-        data: Optional[bytes] = None,
-        timeout: Optional[float] = None,
-    ) -> Any:
-        """Perform an HTTP request against the Space.
-
-        The response body is decoded as JSON when possible; otherwise the raw
-        bytes are returned.
-        """
-
-        if json_payload is not None and data is not None:
-            raise ValueError("Provide either json_payload or data, not both")
-
-        payload: Optional[bytes]
-        headers = self._build_headers()
-        if json_payload is not None:
-            payload = json.dumps(json_payload).encode("utf-8")
-            headers["Content-Type"] = "application/json"
-        else:
-            payload = data
-
-        url = self._build_url(path, params)
-        try:
-            req = request.Request(url, data=payload, headers=headers, method=method.upper())
-            with closing(request.urlopen(req, timeout=timeout)) as resp:
-                raw = resp.read()
-                if not raw:
-                    return {}
-                try:
-                    return json.loads(raw.decode("utf-8"))
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    return raw
-        except error.HTTPError as exc:
-            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
-            raise APIError("Hugging Face Space", message, status=exc.code) from exc
-        except error.URLError as exc:  # pragma: no cover - network failure path
-            raise APIError("Hugging Face Space", str(exc.reason)) from exc
-
-    def get(
-        self,
-        path: str,
-        *,
-        params: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
-        timeout: Optional[float] = None,
-    ) -> Any:
-        """Convenience helper for ``GET`` requests."""
-
-        return self.request(path, method="GET", params=params, timeout=timeout)
-
-    def post(
-        self,
-        path: str,
-        *,
-        json_payload: Optional[Any] = None,
-        data: Optional[bytes] = None,
-        timeout: Optional[float] = None,
-    ) -> Any:
-        """Convenience helper for ``POST`` requests."""
-
-        return self.request(
-            path,
-            method="POST",
-            json_payload=json_payload,
-            data=data,
-            timeout=timeout,
-        )

--- a/cloudflare/worker/src/index.ts
+++ b/cloudflare/worker/src/index.ts
@@ -1,9 +1,32 @@
 export interface Env {
-  NEURO_SPACE_BASE: string;
-  AUDITOR_SPACE_BASE: string;
-  NEURO_SPACE_TOKEN?: string;
-  AUDITOR_SPACE_TOKEN?: string;
+  HF_API_BASE?: string;
+  NEURO_REPO_ID: string;
+  NEURO_REPO_TYPE?: string;
+  NEURO_REPO_REVISION?: string;
+  NEURO_REPO_TOKEN?: string;
+  AUDITOR_REPO_ID: string;
+  AUDITOR_REPO_TYPE?: string;
+  AUDITOR_REPO_REVISION?: string;
+  AUDITOR_REPO_TOKEN?: string;
 }
+
+type RepoScope = "models" | "datasets" | "spaces";
+type RepoLabel = "model" | "dataset" | "space";
+
+type Alias = "neuro" | "auditor";
+
+interface RepoConfig {
+  repoId: string;
+  scope: RepoScope;
+  label: RepoLabel;
+  revision: string;
+  token?: string;
+}
+
+const DEFAULT_BASE = "https://huggingface.co";
+const DEFAULT_REVISION = "main";
+const INFO_ROUTE = "__info__";
+const FILES_ROUTE = "__files__";
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -20,49 +43,64 @@ const HOP_BY_HOP_HEADERS = new Set([
   "cf-visitor",
 ]);
 
-function buildTargetUrl(base: string, suffix: string, search: string): string {
-  const target = new URL(base);
-  const normalizedBase = target.pathname.endsWith("/")
-    ? target.pathname.slice(0, -1)
-    : target.pathname;
-  target.pathname = `${normalizedBase}/${suffix}`.replace(/\/+/g, "/");
-  target.search = search;
-  return target.toString();
+function normalizeRepoType(value?: string | null): { scope: RepoScope; label: RepoLabel } {
+  const normalized = (value ?? "model").toLowerCase().replace(/s$/, "");
+  switch (normalized) {
+    case "model":
+      return { scope: "models", label: "model" };
+    case "dataset":
+      return { scope: "datasets", label: "dataset" };
+    case "space":
+      return { scope: "spaces", label: "space" };
+    default:
+      throw new Error("repo type must be 'model', 'dataset', or 'space'");
+  }
 }
 
-async function proxySpace(
-  request: Request,
-  targetBase: string,
-  token: string | undefined,
-  suffix: string,
-  search: string,
-): Promise<Response> {
-  const init: RequestInit = {
-    method: request.method,
-    headers: new Headers(),
-    redirect: "manual",
-  };
-
-  request.headers.forEach((value, key) => {
-    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
-      init.headers!.set(key, value);
-    }
-  });
-
-  if (token) {
-    init.headers!.set("Authorization", `Bearer ${token}`);
+function readRepoConfig(env: Env, alias: Alias): RepoConfig {
+  const upper = alias.toUpperCase();
+  const bag = env as Record<string, string | undefined>;
+  const repoId = bag[`${upper}_REPO_ID`];
+  if (!repoId) {
+    throw new Error(`Missing ${upper}_REPO_ID`);
   }
+  const { scope, label } = normalizeRepoType(bag[`${upper}_REPO_TYPE`]);
+  const revision = bag[`${upper}_REPO_REVISION`] ?? DEFAULT_REVISION;
+  const token = bag[`${upper}_REPO_TOKEN`];
+  return { repoId, scope, label, revision, token };
+}
 
-  if (request.method !== "GET" && request.method !== "HEAD") {
-    init.body = request.body;
-  }
+function encodeRepoId(repoId: string): string {
+  return repoId
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
 
-  const response = await fetch(buildTargetUrl(targetBase, suffix, search), init);
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: new Headers(response.headers),
-  });
+function encodeRepoPath(path: string): string {
+  return path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildInfoUrl(baseUrl: string, config: RepoConfig): string {
+  return `${baseUrl}/api/${config.scope}/${encodeRepoId(config.repoId)}`;
+}
+
+function buildTreeUrl(baseUrl: string, config: RepoConfig, params: URLSearchParams): string {
+  const encodedRevision = encodeURIComponent(config.revision);
+  const base = `${baseUrl}/api/${config.scope}/${encodeRepoId(config.repoId)}/tree/${encodedRevision}`;
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+}
+
+function buildResolveUrl(baseUrl: string, config: RepoConfig, filePath: string): string {
+  const encodedRevision = encodeURIComponent(config.revision);
+  const encodedPath = encodeRepoPath(filePath);
+  return `${baseUrl}/${encodeRepoId(config.repoId)}/resolve/${encodedRevision}/${encodedPath}`;
 }
 
 function routeSuffix(url: URL, prefix: string): string {
@@ -70,29 +108,174 @@ function routeSuffix(url: URL, prefix: string): string {
   return raw.replace(/^\//, "");
 }
 
+function repoHeaders(token: string | undefined, accept = "application/json"): Headers {
+  const headers = new Headers({ Accept: accept });
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return headers;
+}
+
+function forwardRequestHeaders(request: Request, token: string | undefined, accept?: string): Headers {
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+  if (accept && !headers.has("Accept")) {
+    headers.set("Accept", accept);
+  }
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return headers;
+}
+
+function cloneHeaders(source: Headers): Headers {
+  const headers = new Headers();
+  source.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+  return headers;
+}
+
+function wrapResponse(response: Response): Response {
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: cloneHeaders(response.headers),
+  });
+}
+
+async function fetchRepoInfo(baseUrl: string, config: RepoConfig): Promise<Response> {
+  const response = await fetch(buildInfoUrl(baseUrl, config), {
+    headers: repoHeaders(config.token),
+  });
+  return wrapResponse(response);
+}
+
+async function fetchRepoFiles(baseUrl: string, config: RepoConfig, params: URLSearchParams): Promise<Response> {
+  const search = new URLSearchParams(params);
+  if (search.has("path")) {
+    const raw = search.get("path") ?? "";
+    const cleaned = raw.replace(/^\/+/, "");
+    if (cleaned) {
+      search.set("path", cleaned);
+    } else {
+      search.delete("path");
+    }
+  }
+  if (!search.has("recursive")) {
+    search.set("recursive", "1");
+  }
+  const response = await fetch(buildTreeUrl(baseUrl, config, search), {
+    headers: repoHeaders(config.token),
+  });
+  return wrapResponse(response);
+}
+
+async function fetchRepoFile(request: Request, baseUrl: string, config: RepoConfig, filePath: string): Promise<Response> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  if (!filePath) {
+    return Response.json({ ok: false, error: "File path missing" }, { status: 400 });
+  }
+  const targetUrl = buildResolveUrl(baseUrl, config, filePath);
+  const init: RequestInit = {
+    method: request.method,
+    headers: forwardRequestHeaders(request, config.token, "*/*"),
+    redirect: "manual",
+  };
+  const response = await fetch(targetUrl, init);
+  return wrapResponse(response);
+}
+
+async function handleRepoRequest(
+  request: Request,
+  url: URL,
+  baseUrl: string,
+  prefix: string,
+  config: RepoConfig,
+): Promise<Response> {
+  const suffix = routeSuffix(url, prefix);
+  if (!suffix || suffix === INFO_ROUTE) {
+    return fetchRepoInfo(baseUrl, config);
+  }
+
+  const [command, ...rest] = suffix.split("/");
+  if (command === INFO_ROUTE) {
+    return fetchRepoInfo(baseUrl, config);
+  }
+  if (command === FILES_ROUTE) {
+    const params = new URLSearchParams(url.search);
+    if (rest.length > 0 && !params.has("path")) {
+      const inferred = rest.join("/");
+      if (inferred) {
+        params.set("path", inferred);
+      }
+    }
+    return fetchRepoFiles(baseUrl, config, params);
+  }
+
+  return fetchRepoFile(request, baseUrl, config, suffix);
+}
+
+function summarizeAlias(env: Env, alias: Alias): Record<string, string> {
+  try {
+    const config = readRepoConfig(env, alias);
+    return {
+      repoId: config.repoId,
+      repoType: config.label,
+      revision: config.revision,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: message };
+  }
+}
+
+function errorResponse(message: string, status = 500): Response {
+  return Response.json({ ok: false, error: message }, { status });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+    const baseUrl = env.HF_API_BASE ?? DEFAULT_BASE;
+    const aliases: Alias[] = ["neuro", "auditor"];
 
-    if (url.pathname.startsWith("/neuro/")) {
-      const suffix = routeSuffix(url, "/neuro");
-      return proxySpace(request, env.NEURO_SPACE_BASE, env.NEURO_SPACE_TOKEN, suffix, url.search);
-    }
-
-    if (url.pathname.startsWith("/auditor/")) {
-      const suffix = routeSuffix(url, "/auditor");
-      return proxySpace(request, env.AUDITOR_SPACE_BASE, env.AUDITOR_SPACE_TOKEN, suffix, url.search);
+    for (const alias of aliases) {
+      const prefix = `/${alias}`;
+      if (url.pathname === prefix || url.pathname.startsWith(`${prefix}/`)) {
+        try {
+          const config = readRepoConfig(env, alias);
+          return handleRepoRequest(request, url, baseUrl, prefix, config);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return errorResponse(message, 500);
+        }
+      }
     }
 
     if (url.pathname === "/" || url.pathname === "") {
+      const repos: Record<string, Record<string, string>> = {};
+      for (const alias of aliases) {
+        repos[alias] = summarizeAlias(env, alias);
+      }
       return Response.json(
         {
           ok: true,
-          message: "Proxy Worker online",
+          message: "Repository proxy online",
           routes: {
-            neuro: "/neuro/*",
-            auditor: "/auditor/*",
+            info: INFO_ROUTE,
+            files: FILES_ROUTE,
+            raw: "<alias>/<file path>",
           },
+          repos,
         },
         { headers: { "Cache-Control": "no-store" } },
       );

--- a/cloudflare/worker/wrangler.toml
+++ b/cloudflare/worker/wrangler.toml
@@ -4,8 +4,13 @@ compatibility_date = "2024-09-05"
 workers_dev = true
 
 [vars]
-NEURO_SPACE_BASE = "https://darkfrostx-neuro-mechanism-backend.hf.space"
-AUDITOR_SPACE_BASE = "https://darkfrostx-ssra-auditor.hf.space"
+HF_API_BASE = "https://huggingface.co"
+NEURO_REPO_ID = "darkfrostx/neuro-mechanism-backend"
+NEURO_REPO_TYPE = "space"
+NEURO_REPO_REVISION = "main"
+AUDITOR_REPO_ID = "darkfrostx/ssra-auditor"
+AUDITOR_REPO_TYPE = "space"
+AUDITOR_REPO_REVISION = "main"
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary
- document repository-centric workflows in the README with repository-first CLI examples and worker guidance
- focus the Hugging Face client and CLI on repository metadata and file listings with refreshed unit tests
- replace the Cloudflare Worker proxy with a repository-aware implementation and update Wrangler defaults

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf4df3a3f0832984094b480ca5bd8e