### PR TITLE
Add Cloudflare worker service utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,18 @@ python -m aion.cli cloudflare list-zones
 
 # Create a Workers KV namespace (requires account id)
 python -m aion.cli cloudflare --account-id <ACCOUNT_ID> create-kv-namespace "My Namespace"
+
+# Discover Worker services (new in this release)
+python -m aion.cli cloudflare --account-id <ACCOUNT_ID> list-worker-services
+
+# Inspect a specific service and show its environments
+python -m aion.cli cloudflare --account-id <ACCOUNT_ID> worker-service-info ssra-orchestrator --include-environments
+
+# Download the production script for a service
+python -m aion.cli cloudflare --account-id <ACCOUNT_ID> worker-service-script ssra-orchestrator --environment production --output cloudflare/ssra-orchestrator.js
 ```
+
+These helpers make it easy to pull existing Worker services—such as `ssra-orchestrator` or `ssra-gateway`—into the repository. Save the downloaded script anywhere under `cloudflare/` (for example `cloudflare/ssra-orchestrator/index.js`) and pair it with a `wrangler.toml` that matches the remote configuration so everything is versioned alongside the Hugging Face worker.
 
 ## Cloudflare Worker for Hugging Face repositories
 [`cloudflare/worker`](cloudflare/worker/) contains a Worker that understands Hugging Face repositories and a pinned revision for each route alias. It exposes three behaviours per alias (`/neuro/*` and `/auditor/*` by default):

--- a/aion/cloudflare_client.py
+++ b/aion/cloudflare_client.py
@@ -19,11 +19,19 @@ class CloudflareClient:
     account_id: Optional[str] = None
     base_url: str = "https://api.cloudflare.com/client/v4"
 
-    def _build_headers(self, content_type: str = "application/json") -> Dict[str, str]:
+    def _build_headers(
+        self,
+        content_type: Optional[str] = "application/json",
+        *,
+        accept: Optional[str] = None,
+    ) -> Dict[str, str]:
         headers = {
             "Authorization": f"Bearer {self.token}",
-            "Content-Type": content_type,
         }
+        if content_type:
+            headers["Content-Type"] = content_type
+        if accept:
+            headers["Accept"] = accept
         return headers
 
     def list_zones(self, name: Optional[str] = None) -> Any:
@@ -91,3 +99,58 @@ class CloudflareClient:
             errors = data.get("errors") or "Unknown error"
             raise APIError("Cloudflare", str(errors))
         return data
+
+    def _require_account_id(self) -> str:
+        if not self.account_id:
+            raise ValueError("account_id is required for this operation")
+        return self.account_id
+
+    def list_worker_services(self) -> Any:
+        """Return Worker services available on the current account."""
+
+        account_id = self._require_account_id()
+        url = f"{self.base_url}/accounts/{account_id}/workers/services"
+        data = self._request(url)
+        return data.get("result", [])
+
+    def get_worker_service(self, service: str) -> Dict[str, Any]:
+        """Fetch metadata about a specific Worker service."""
+
+        account_id = self._require_account_id()
+        encoded = parse.quote(service, safe="")
+        url = f"{self.base_url}/accounts/{account_id}/workers/services/{encoded}"
+        data = self._request(url)
+        return data.get("result", {})
+
+    def list_worker_service_environments(self, service: str) -> Any:
+        """List environments configured for a Worker service."""
+
+        account_id = self._require_account_id()
+        encoded = parse.quote(service, safe="")
+        url = (
+            f"{self.base_url}/accounts/{account_id}/workers/services/{encoded}/environments"
+        )
+        data = self._request(url)
+        return data.get("result", [])
+
+    def get_worker_service_script(self, service: str, environment: str = "production") -> str:
+        """Download the Worker script for an environment as plain text."""
+
+        account_id = self._require_account_id()
+        encoded_service = parse.quote(service, safe="")
+        encoded_env = parse.quote(environment, safe="")
+        url = (
+            f"{self.base_url}/accounts/{account_id}/workers/services/"
+            f"{encoded_service}/environments/{encoded_env}/content"
+        )
+
+        try:
+            headers = self._build_headers(content_type=None, accept="application/javascript")
+            req = request.Request(url, headers=headers)
+            with closing(request.urlopen(req)) as resp:
+                return resp.read().decode("utf-8")
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Cloudflare", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Cloudflare", str(exc.reason)) from exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add Cloudflare client helpers to list worker services, fetch metadata, and download scripts
- extend the Cloudflare CLI with commands for inspecting worker services and persisting scripts locally
- document the workflow for importing existing Workers and expand the unit test suite (including shared pytest path setup)

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08e2b4f6c8329b62cd8f3f94d3bb0