### PR TITLE
Add smoke test automation for Hugging Face and Cloudflare

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# --- HUGGING FACE ---
+HF_TOKEN=hf_xxx
+HF_USERNAME=your-hf-username
+HF_NEURO_SPACE=darkfrostx/neuro-mechanism-backend
+HF_AUDITOR_SPACE=darkfrostx/ssra-auditor
+
+# --- CLOUDFLARE ---
+CF_API_TOKEN=cf_xxx
+CF_ACCOUNT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Optional: override the worker name if Wrangler cannot infer it
+CF_SCRIPT_NAME=
+
+# --- WORKER PROJECT DIR (relative to repo root) ---
+WORKER_DIR=cloudflare/worker
+
+# --- WHAT PATHS TO HIT ON EACH BACKEND (through the proxy) ---
+NEURO_PING=/__info__
+AUDITOR_PING=/__info__
+
+# --- TIMEOUTS/RETRIES ---
+SMOKE_MAX_RETRIES=30
+SMOKE_SLEEP_SECONDS=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.pyc
+node_modules/
+.smoke/
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ifneq (,$(wildcard .env))
+include .env
+export
+endif
+
+.PHONY: smoke smoke-hf smoke-cf smoke-clean
+
+smoke: smoke-hf smoke-cf
+@echo "=== ALL CHECKS PASSED ==="
+
+smoke-hf:
+@bash scripts/smoke.sh hf
+
+smoke-cf:
+@bash scripts/smoke.sh cf
+
+smoke-clean:
+@rm -rf .smoke
+@echo "Cleaned .smoke/"

--- a/aion/cloudflare_client.py
+++ b/aion/cloudflare_client.py
@@ -19,11 +19,19 @@ class CloudflareClient:
     account_id: Optional[str] = None
     base_url: str = "https://api.cloudflare.com/client/v4"
 
-    def _build_headers(self, content_type: str = "application/json") -> Dict[str, str]:
+    def _build_headers(
+        self,
+        content_type: Optional[str] = "application/json",
+        *,
+        accept: Optional[str] = None,
+    ) -> Dict[str, str]:
         headers = {
             "Authorization": f"Bearer {self.token}",
-            "Content-Type": content_type,
         }
+        if content_type:
+            headers["Content-Type"] = content_type
+        if accept:
+            headers["Accept"] = accept
         return headers
 
     def list_zones(self, name: Optional[str] = None) -> Any:
@@ -91,3 +99,58 @@ class CloudflareClient:
             errors = data.get("errors") or "Unknown error"
             raise APIError("Cloudflare", str(errors))
         return data
+
+    def _require_account_id(self) -> str:
+        if not self.account_id:
+            raise ValueError("account_id is required for this operation")
+        return self.account_id
+
+    def list_worker_services(self) -> Any:
+        """Return Worker services available on the current account."""
+
+        account_id = self._require_account_id()
+        url = f"{self.base_url}/accounts/{account_id}/workers/services"
+        data = self._request(url)
+        return data.get("result", [])
+
+    def get_worker_service(self, service: str) -> Dict[str, Any]:
+        """Fetch metadata about a specific Worker service."""
+
+        account_id = self._require_account_id()
+        encoded = parse.quote(service, safe="")
+        url = f"{self.base_url}/accounts/{account_id}/workers/services/{encoded}"
+        data = self._request(url)
+        return data.get("result", {})
+
+    def list_worker_service_environments(self, service: str) -> Any:
+        """List environments configured for a Worker service."""
+
+        account_id = self._require_account_id()
+        encoded = parse.quote(service, safe="")
+        url = (
+            f"{self.base_url}/accounts/{account_id}/workers/services/{encoded}/environments"
+        )
+        data = self._request(url)
+        return data.get("result", [])
+
+    def get_worker_service_script(self, service: str, environment: str = "production") -> str:
+        """Download the Worker script for an environment as plain text."""
+
+        account_id = self._require_account_id()
+        encoded_service = parse.quote(service, safe="")
+        encoded_env = parse.quote(environment, safe="")
+        url = (
+            f"{self.base_url}/accounts/{account_id}/workers/services/"
+            f"{encoded_service}/environments/{encoded_env}/content"
+        )
+
+        try:
+            headers = self._build_headers(content_type=None, accept="application/javascript")
+            req = request.Request(url, headers=headers)
+            with closing(request.urlopen(req)) as resp:
+                return resp.read().decode("utf-8")
+        except error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="ignore") or exc.reason
+            raise APIError("Cloudflare", message, status=exc.code) from exc
+        except error.URLError as exc:  # pragma: no cover - network failure path
+            raise APIError("Cloudflare", str(exc.reason)) from exc

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,156 @@
+# Integrating Hugging Face Spaces with the Cloudflare Worker
+
+The repository contains everything you need to connect the `darkfrostx/neuro-mechanism-backend` and `darkfrostx/ssra-auditor` Hugging Face Spaces to the Cloudflare worker that proxies their metadata, file listings, and raw file contents. The steps below walk through the full workflow at a "one minute per step" pace so you can follow along without prior experience.
+
+---
+
+## 0. Prerequisites checklist
+
+| Tool | Why you need it | How to install |
+| --- | --- | --- |
+| Python 3.9+ | Runs the `aion` command-line helpers | <https://www.python.org/downloads/> |
+| Git + Git LFS | Pulls and pushes Space repositories | <https://git-scm.com/download/win> (select the default Git LFS option during setup) |
+| Node.js 18+ | Provides the runtime for Cloudflare's Wrangler CLI | <https://nodejs.org/en> (LTS or current) |
+| Wrangler CLI | Deploys the worker | `npm install -g wrangler` |
+
+> **Tip:** After installation, reopen PowerShell or your terminal so the new commands (`git`, `node`, `wrangler`) are available.
+
+---
+
+## 1. Prepare Hugging Face access
+
+1. Log in at <https://huggingface.co/settings/tokens>.
+2. Click **New token**, name it (for example, `worker-integration`), choose the **Write** role, and click **Create**.
+3. Copy the token and keep it safe – you will paste it when Git or the CLI asks for a password.
+4. Optional: store it in an environment variable while working in a terminal session:
+   ```powershell
+   setx HF_TOKEN "hf_xxx"  # on Windows (opens a new session to take effect)
+   export HF_TOKEN=hf_xxx   # on macOS/Linux
+   ```
+
+---
+
+## 2. Clone the Spaces locally (read/write access test)
+
+Perform the steps below for **each** Space (`neuro-mechanism-backend` and `ssra-auditor`).
+
+1. Create a folder to hold the clones and move into it:
+   ```powershell
+   mkdir "$HOME\Documents\hf-spaces"
+   cd "$HOME\Documents\hf-spaces"
+   ```
+2. Clone the Space:
+   ```powershell
+   git clone https://huggingface.co/spaces/darkfrostx/neuro-mechanism-backend
+   ```
+   *(Repeat with `darkfrostx/ssra-auditor`)*
+3. Open the folder in File Explorer if you prefer a GUI:
+   ```powershell
+   Start-Process "$HOME\Documents\hf-spaces"
+   ```
+4. Make a small reversible change (for example, append `# integration test` to `README.md`).
+5. Back in the terminal, commit and push the change to confirm write access:
+   ```powershell
+   git status
+   git add .
+   git commit -m "Integration test"
+   git push
+   ```
+   When prompted:
+   * Username → your Hugging Face username (`darkfrostx`).
+   * Password → the write token you generated.
+6. Undo the test change if you do not want to keep it:
+   ```powershell
+   git revert HEAD
+   git push
+   ```
+
+---
+
+## 3. Explore the Spaces using the AION CLI (read-only)
+
+1. Open a terminal in the project root (the folder with `README.md`, `aion/`, and `cloudflare/`).
+2. View the CLI help to confirm it is available:
+   ```powershell
+   python -m aion.cli --help
+   ```
+3. Inspect metadata for each Space:
+   ```powershell
+   python -m aion.cli huggingface repo-info darkfrostx/neuro-mechanism-backend --repo-type space --token hf_xxx
+   python -m aion.cli huggingface repo-info darkfrostx/ssra-auditor --repo-type space --token hf_xxx
+   ```
+4. List the tracked files on `main` (read-only):
+   ```powershell
+   python -m aion.cli huggingface repo-files darkfrostx/neuro-mechanism-backend --repo-type space --revision main --token hf_xxx
+   python -m aion.cli huggingface repo-files darkfrostx/ssra-auditor --repo-type space --revision main --token hf_xxx
+   ```
+5. Download a specific file if you need to review it locally (optional):
+   ```powershell
+   python -m aion.cli huggingface download darkfrostx/neuro-mechanism-backend README.md --repo-type space --revision main --output README.md --token hf_xxx
+   ```
+
+---
+
+## 4. Deploy the Cloudflare worker
+
+1. Authenticate Wrangler:
+   ```powershell
+   wrangler login
+   ```
+   Approve the browser prompt.
+2. Move into the worker folder and install dependencies:
+   ```powershell
+   cd cloudflare/worker
+   npm install
+   ```
+3. (Optional) If you ever make a Space private, add the matching secret so the worker forwards the token automatically:
+   ```powershell
+   wrangler secret put NEURO_REPO_TOKEN
+   wrangler secret put AUDITOR_REPO_TOKEN
+   ```
+   Answer **yes** when Wrangler asks to create/use `aion-neuro-auditor-proxy`.
+4. Deploy:
+   ```powershell
+   npm run deploy
+   ```
+   Wrangler prints a `workers.dev` URL such as `https://aion-neuro-auditor-proxy.<name>.workers.dev`.
+5. Verify the routes:
+   * `https://<worker-domain>/neuro/__info__`
+   * `https://<worker-domain>/neuro/__files__?recursive=0`
+   * `https://<worker-domain>/auditor/__info__`
+   * `https://<worker-domain>/auditor/__files__?recursive=0`
+
+---
+
+## 5. Keep everything in sync
+
+* Edit your Spaces locally, push with `git`, and redeploy the worker with `npm run deploy` whenever you change the proxy logic.
+* Use `wrangler tail` while exercising the worker to watch live logs:
+  ```powershell
+  wrangler tail --env production
+  ```
+* Rotate Hugging Face tokens by updating the secrets (`wrangler secret put ...`) and redeploying.
+
+---
+
+## Troubleshooting quick reference
+
+| Symptom | Fix |
+| --- | --- |
+| `python -m aion.cli …` reports `ModuleNotFoundError` | Change directory to the project root where the `aion/` package lives before running the command. |
+| `git push` prompts for a password | Always use the Hugging Face **write token** instead of your account password (password-based pushes are disabled). |
+| Wrangler asks to create a worker during `secret put` | Answer **yes** — it links the secret to the `aion-neuro-auditor-proxy` worker defined in `wrangler.toml`. |
+| Worker returns 403 for a private Space | Store the corresponding `*_REPO_TOKEN` secret so requests include the token. |
+
+---
+
+## Optional: run the end-to-end smoke test
+
+After you have working credentials, you can automate every step above in a single command:
+
+1. Copy `.env.example` to `.env` and fill in your Hugging Face username/token plus the Cloudflare API token and account ID.
+2. From the repository root run `make smoke`.
+
+The script will clone both Spaces into `.smoke/`, push a timestamped `CODEx_OK.txt` file to trigger rebuilds, publish the worker through Wrangler, and poll the `/neuro/__info__` and `/auditor/__info__` routes via the worker until they return HTTP 200. Use `make smoke-hf` or `make smoke-cf` to run only one side, and `make smoke-clean` to remove the temporary workspace.
+
+By following these steps you confirm end-to-end control: edit both Hugging Face Spaces, deploy the worker proxy, and test the integrated routes without needing any additional repositories or hidden automation.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-all}"
+ROOT_DIR="$(pwd)"
+WORK_DIR="$ROOT_DIR/.smoke"
+mkdir -p "$WORK_DIR"
+
+if [ -f "$ROOT_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$ROOT_DIR/.env"
+  set +a
+fi
+
+log()  { printf "\033[1;36m%s\033[0m\n" "$*"; }
+ok()   { printf "\033[1;32m%s\033[0m\n" "$*"; }
+warn() { printf "\033[1;33m%s\033[0m\n" "$*"; }
+err()  { printf "\033[1;31m%s\033[0m\n" "$*"; }
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "Missing dependency: $1"
+    exit 1
+  fi
+}
+
+require_env() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    err "Missing env var: $var"
+    exit 1
+  fi
+}
+
+clone_or_update_space() {
+  local space="$1"
+  local dir="$2"
+  local hf_url="https://huggingface.co/spaces/$space"
+
+  if [ -d "$dir/.git" ]; then
+    log "Updating $space ..."
+    git -C "$dir" pull --ff-only
+  else
+    log "Cloning $space ..."
+    if command -v huggingface-cli >/dev/null 2>&1; then
+      git clone "$hf_url" "$dir"
+    else
+      require_env HF_USERNAME
+      require_env HF_TOKEN
+      git clone "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${space}" "$dir"
+    fi
+  fi
+}
+
+push_smoke_commit() {
+  local dir="$1"
+  local tag="$2"
+  local space="$3"
+
+  log "Creating smoke commit in $(basename "$dir") ..."
+  git -C "$dir" config user.email "codex@local"
+  git -C "$dir" config user.name  "Codex Smoke"
+  printf "codex smoke test %s\n" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" > "$dir/CODEx_OK.txt"
+  git -C "$dir" add CODEx_OK.txt
+  git -C "$dir" commit -m "codex: smoke test ${tag}" || warn "No changes to commit (already smoke-tested)"
+
+  if ! git -C "$dir" push 2>/dev/null; then
+    require_env HF_USERNAME
+    require_env HF_TOKEN
+    git -C "$dir" remote set-url origin "https://${HF_USERNAME}:${HF_TOKEN}@huggingface.co/spaces/${space}"
+    git -C "$dir" push
+  fi
+  ok "Pushed smoke commit → Space will rebuild."
+}
+
+deploy_worker() {
+  local wdir="$1"
+  log "Publishing Worker from $wdir ..."
+  local out="$WORK_DIR/wrangler.out"
+  (cd "$wdir" && npx --yes wrangler publish | tee "$out") || {
+    err "Wrangler publish failed"
+    exit 1
+  }
+
+  local url
+  url="$(grep -Eo 'https://[a-zA-Z0-9._/-]+\.workers\.dev' "$out" | tail -1 || true)"
+  if [ -z "$url" ] && [ -n "${CF_SCRIPT_NAME:-}" ]; then
+    warn "Could not parse workers.dev URL from output. If you know it, set CF_WORKER_URL in .env."
+  fi
+  echo "$url"
+}
+
+await_200() {
+  local url="$1"
+  local name="$2"
+  local max="${SMOKE_MAX_RETRIES:-30}"
+  local slp="${SMOKE_SLEEP_SECONDS:-5}"
+
+  log "Probing $name → $url"
+  for ((i=1; i<=max; i++)); do
+    code="$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)"
+    if [ "$code" = "200" ]; then
+      ok "$name OK (200)"
+      return 0
+    fi
+    printf " [%d/%d] got %s, retrying in %ss...\n" "$i" "$max" "${code:-err}" "$slp"
+    sleep "$slp"
+  done
+  err "$name FAILED (no 200 after $max tries)"
+  return 1
+}
+
+run_hf() {
+  need git
+  need curl
+  if command -v huggingface-cli >/dev/null 2>&1; then
+    if [ -n "${HF_TOKEN:-}" ]; then
+      log "huggingface-cli login (non-interactive)"
+      huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential -y || true
+    fi
+  fi
+
+  require_env HF_NEURO_SPACE
+  require_env HF_AUDITOR_SPACE
+
+  local neuro_dir="$WORK_DIR/neuro-mechanism-backend"
+  local audit_dir="$WORK_DIR/ssra-auditor"
+
+  clone_or_update_space "$HF_NEURO_SPACE" "$neuro_dir"
+  clone_or_update_space "$HF_AUDITOR_SPACE" "$audit_dir"
+
+  push_smoke_commit "$neuro_dir" "neuro" "$HF_NEURO_SPACE"
+  push_smoke_commit "$audit_dir" "auditor" "$HF_AUDITOR_SPACE"
+
+  ok "Hugging Face push phase complete."
+}
+
+run_cf() {
+  need node
+  need npm
+  need curl
+  require_env CF_API_TOKEN
+  require_env CF_ACCOUNT_ID
+  require_env WORKER_DIR
+
+  local url="${CF_WORKER_URL:-}"
+  if [ -z "$url" ]; then
+    url="$(deploy_worker "$ROOT_DIR/$WORKER_DIR")"
+  fi
+
+  if [ -z "$url" ]; then
+    warn "Worker URL unknown. You can still test manually once you know it."
+    exit 1
+  fi
+
+  local neuro_path="${NEURO_PING:-/__info__}"
+  local auditor_path="${AUDITOR_PING:-/__info__}"
+
+  await_200 "${url%/}/neuro${neuro_path}"   "NEURO via Worker"
+  await_200 "${url%/}/auditor${auditor_path}" "AUDITOR via Worker"
+
+  ok "Cloudflare proxy checks passed."
+}
+
+case "$MODE" in
+  hf) run_hf ;;
+  cf) run_cf ;;
+  all) run_hf; run_cf ;;
+  *) err "Usage: $0 [hf|cf|all]"; exit 1 ;;
+esac
+
+ok "SMOKE COMPLETE."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a reusable smoke test script, Makefile, and .env template to automate Space pushes and Worker deployment checks
- document the smoke workflow in the README and integration guide so it is easy to run end-to-end validation
- update .gitignore to exclude node_modules, .smoke, and .env artifacts created by the smoke tooling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08e2b4f6c8329b62cd8f3f94d3bb0